### PR TITLE
[BlindOutputs] Use input blinders to blind transaction outputs

### DIFF
--- a/src/confidential.js
+++ b/src/confidential.js
@@ -62,6 +62,23 @@ function unblindOutput(
   };
 }
 exports.unblindOutput = unblindOutput;
+function unblindWitnessUtxo(prevout, blindingPrivKey) {
+  const unblindProof = unblindOutput(
+    prevout.nonce,
+    blindingPrivKey,
+    prevout.rangeProof,
+    prevout.value,
+    prevout.asset,
+    prevout.script,
+  );
+  return {
+    satoshis: parseInt(unblindProof.value, 10),
+    amountBlinder: unblindProof.valueBlindingFactor.toString('hex'),
+    asset: unblindProof.asset.toString('hex'),
+    assetBlinder: unblindProof.assetBlindingFactor.toString('hex'),
+  };
+}
+exports.unblindWitnessUtxo = unblindWitnessUtxo;
 function rangeProofInfo(proof) {
   const { exp, mantissa, minValue, maxValue } = secp256k1.rangeproof.info(
     proof,

--- a/src/confidential.js
+++ b/src/confidential.js
@@ -37,19 +37,19 @@ function assetCommitment(asset, factor) {
   return secp256k1.generator.serialize(generator);
 }
 exports.assetCommitment = assetCommitment;
-function unblindOutputWithKey(prevout, blindingPrivKey) {
-  const nonce = nonceHash(prevout.nonce, blindingPrivKey);
-  return unblindOutputWithNonce(prevout, nonce);
+function unblindOutputWithKey(out, blindingPrivKey) {
+  const nonce = nonceHash(out.nonce, blindingPrivKey);
+  return unblindOutputWithNonce(out, nonce);
 }
 exports.unblindOutputWithKey = unblindOutputWithKey;
-function unblindOutputWithNonce(prevout, nonce) {
-  const gen = secp256k1.generator.parse(prevout.asset);
+function unblindOutputWithNonce(out, nonce) {
+  const gen = secp256k1.generator.parse(out.asset);
   const { value, blindFactor, message } = secp256k1.rangeproof.rewind(
-    prevout.value,
-    prevout.rangeProof,
+    out.value,
+    out.rangeProof,
     nonce,
     gen,
-    prevout.script,
+    out.script,
   );
   return {
     value,

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -1441,7 +1441,7 @@ function toBlindingData(blindDataLike, witnessUtxo) {
   }
   if (Buffer.isBuffer(blindDataLike)) {
     if (!witnessUtxo) throw new Error('need witnessUtxo');
-    return confidential.unblindWitnessUtxo(witnessUtxo, blindDataLike);
+    return confidential.unblindOutputWithKey(witnessUtxo, blindDataLike);
   }
   return blindDataLike;
 }

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -600,15 +600,15 @@ class Psbt {
     this.data.clearFinalizedInput(inputIndex);
     return this;
   }
-  rawBlindOutputs(blindingPrivkeys, blindingPubkeys, outputIndexes, opts) {
+  rawBlindOutputs(blindingDataLike, blindingPubkeys, outputIndexes, opts) {
     if (this.data.inputs.some(v => !v.nonWitnessUtxo && !v.witnessUtxo))
       throw new Error(
         'All inputs must contain a non witness utxo or a witness utxo',
       );
     const c = this.__CACHE;
-    if (c.__TX.ins.length !== blindingPrivkeys.length) {
+    if (c.__TX.ins.length !== blindingDataLike.length) {
       throw new Error(
-        'blindingPrivkeys length does not match the number of inputs (null for unconfidential utxo)',
+        'blindingDataLike length does not match the number of inputs (undefined for unconfidential utxo)',
       );
     }
     if (!outputIndexes) {
@@ -622,85 +622,71 @@ class Psbt {
       throw new Error(
         'not enough blinding public keys to blind the requested outputs',
       );
-    const outputValues = c.__TX.outs.map(v =>
-      confidential.confidentialValueToSatoshi(v.value).toString(10),
-    );
-    const inputAbfs = [];
-    const inputVbfs = [];
-    const inputAgs = [];
-    const inputValues = [];
-    // iterate through inputs to fetch blind data
-    this.data.inputs.forEach((input, index) => {
-      let prevout;
+    const witnesses = this.data.inputs.map((input, index) => {
       if (input.nonWitnessUtxo) {
         const prevTx = nonWitnessUtxoTxFromCache(c, input, index);
         const prevoutIndex = c.__TX.ins[index].index;
-        prevout = prevTx.outs[prevoutIndex];
-      } else {
-        prevout = Object.assign({}, input.witnessUtxo);
+        return prevTx.outs[prevoutIndex];
       }
-      const blindingPrivKey = blindingPrivkeys[index];
-      const blindingData = getBlindingDataForInput(prevout, blindingPrivKey);
-      inputAgs.push(blindingData.ag);
-      inputValues.push(blindingData.value);
-      inputAbfs.push(blindingData.abf);
-      inputVbfs.push(blindingData.vbf);
+      if (input.witnessUtxo) {
+        return input.witnessUtxo;
+      }
+      throw new Error('input data needs witness utxo or nonwitness utxo');
     });
-    // generate output blinding factors
-    const numOutputs = outputIndexes.length;
-    const outputAbfs = range(numOutputs).map(() => randomBytes(opts));
-    const outputVbfs = range(numOutputs - 1).map(() => randomBytes(opts));
-    // fitler outputValues to get only the confidential outputs amounts
-    const confidentialOutputValues = outputValues.filter((_, index) =>
-      outputIndexes.includes(index),
+    const inputsBlindingData = blindingDataLike.map((data, i) =>
+      toBlindingData(data, witnesses[i]),
     );
-    const finalVbf = confidential.valueBlindingFactor(
-      inputValues,
-      confidentialOutputValues,
-      inputAbfs,
-      outputAbfs,
-      inputVbfs,
-      outputVbfs,
-    );
-    outputVbfs.push(finalVbf);
-    outputIndexes.forEach((outputIndex, indexInArray) => {
-      const outputAsset = c.__TX.outs[outputIndex].asset.slice(1);
-      const outputScript = c.__TX.outs[outputIndex].script;
-      const outputValue = outputValues[outputIndex];
-      // if script output is null it means that the current is a fee output
-      // thus, throw an error
-      if (outputScript.length === 0)
+    // get data (satoshis & asset) outputs to blind
+    const outputsData = outputIndexes.map(index => {
+      const output = c.__TX.outs[index];
+      // prevent blinding the fee output
+      if (output.script.length === 0)
         throw new Error("cant't blind the fee output");
-      // blind output
+      const value = confidential.confidentialValueToSatoshi(output.value);
+      return [value, output.asset.slice(1).toString('hex')];
+    });
+    // compute the outputs blinders
+    const outputsBlindingData = computeOutputsBlindingData(
+      inputsBlindingData,
+      outputsData,
+    );
+    // use blinders to compute proofs & commitments
+    outputIndexes.forEach((outputIndex, indexInArray) => {
       const randomSeed = randomBytes(opts);
       const ephemeralPrivKey = randomBytes(opts);
       const outputNonce = ecpair_1.fromPrivateKey(ephemeralPrivKey).publicKey;
+      const outputBlindingData = outputsBlindingData[indexInArray];
+      // commitments
       const assetCommitment = confidential.assetCommitment(
-        outputAsset,
-        outputAbfs[indexInArray],
+        Buffer.from(outputBlindingData.asset, 'hex'),
+        Buffer.from(outputBlindingData.assetBlinder, 'hex'),
       );
       const valueCommitment = confidential.valueCommitment(
-        outputValue,
+        outputBlindingData.satoshis.toString(10),
         assetCommitment,
-        outputVbfs[indexInArray],
+        Buffer.from(outputBlindingData.amountBlinder, 'hex'),
       );
+      // proofs
       const rangeProof = confidential.rangeProof(
-        outputValue,
+        outputBlindingData.satoshis.toString(10),
         blindingPubkeys[indexInArray],
         ephemeralPrivKey,
-        outputAsset,
-        outputAbfs[indexInArray],
-        outputVbfs[indexInArray],
+        Buffer.from(outputBlindingData.asset, 'hex'),
+        Buffer.from(outputBlindingData.assetBlinder, 'hex'),
+        Buffer.from(outputBlindingData.amountBlinder, 'hex'),
         valueCommitment,
-        outputScript,
+        c.__TX.outs[outputIndex].script,
       );
       const surjectionProof = confidential.surjectionProof(
-        outputAsset,
-        outputAbfs[indexInArray],
-        inputAgs,
-        inputAbfs,
+        Buffer.from(outputBlindingData.asset, 'hex'),
+        Buffer.from(outputBlindingData.assetBlinder, 'hex'),
+        inputsBlindingData.map(({ asset }) => Buffer.from(asset, 'hex')),
+        inputsBlindingData.map(({ assetBlinder }) =>
+          Buffer.from(assetBlinder, 'hex'),
+        ),
         randomSeed,
       );
+      // set commitments & proofs & nonce
       c.__TX.outs[outputIndex].asset = assetCommitment;
       c.__TX.outs[outputIndex].value = valueCommitment;
       c.__TX.setOutputNonce(outputIndex, outputNonce);
@@ -1389,20 +1375,85 @@ function randomBytes(options) {
   const rng = options.rng || _randomBytes;
   return rng(32);
 }
-function getBlindingDataForInput(prevout, blindPrivKey) {
-  // check if confidential
-  if (blindPrivKey) {
-    return unblindWitnessUtxo(prevout, blindPrivKey);
+/**
+ * Compute outputs blinders
+ * @param inputsBlindingData the transaction inputs blinding data
+ * @param outputsData data = [satoshis, asset] of output to blind
+ * @returns an array of BlindingData[] corresponding of blinders to blind outputs specified in outputsData
+ */
+function computeOutputsBlindingData(inputsBlindingData, outputsData) {
+  const outputsBlindingData = [];
+  outputsData.forEach(([satoshis, asset], outputIndex) => {
+    const blindingData = {
+      satoshis,
+      asset,
+      assetBlinder: randomBlinder(),
+      amountBlinder: '',
+    };
+    if (outputIndex === outputsData.length - 1) {
+      // tslint:disable-next-line:no-shadowed-variable
+      const inputsValues = inputsBlindingData.map(({ satoshis }) =>
+        satoshis.toString(10),
+      );
+      const outputsValues = outputsData
+        .map(([amount]) => amount.toString(10))
+        .concat(satoshis.toString(10));
+      const inputsAssetBlinders = inputsBlindingData.map(({ assetBlinder }) =>
+        Buffer.from(assetBlinder, 'hex'),
+      );
+      const outputsAssetBlinders = outputsBlindingData
+        .map(({ assetBlinder }) => Buffer.from(assetBlinder, 'hex'))
+        .concat(Buffer.from(blindingData.assetBlinder, 'hex'));
+      const inputsAmountBlinders = inputsBlindingData.map(({ amountBlinder }) =>
+        Buffer.from(amountBlinder, 'hex'),
+      );
+      const outputsAmountBlinders = outputsBlindingData.map(
+        ({ amountBlinder }) => Buffer.from(amountBlinder, 'hex'),
+      );
+      const finalAmountBlinder = confidential
+        .valueBlindingFactor(
+          inputsValues,
+          outputsValues,
+          inputsAssetBlinders,
+          outputsAssetBlinders,
+          inputsAmountBlinders,
+          outputsAmountBlinders,
+        )
+        .toString('hex');
+      blindingData.amountBlinder = finalAmountBlinder;
+    } else {
+      blindingData.amountBlinder = randomBlinder();
+    }
+    outputsBlindingData.push(blindingData);
+  });
+  return outputsBlindingData;
+}
+exports.computeOutputsBlindingData = computeOutputsBlindingData;
+function toBlindingData(blindDataLike, witnessUtxo) {
+  if (!blindDataLike) {
+    if (!witnessUtxo) throw new Error('need witnessUtxo');
+    return getUnblindedWitnessUtxoBlindingData(witnessUtxo);
   }
+  if (Buffer.isBuffer(blindDataLike)) {
+    if (!witnessUtxo) throw new Error('need witnessUtxo');
+    return getBlindedWitnessUtxoBlindingData(witnessUtxo, blindDataLike);
+  }
+  return blindDataLike;
+}
+exports.toBlindingData = toBlindingData;
+function randomBlinder() {
+  return randomBytes().toString('hex');
+}
+function getUnblindedWitnessUtxoBlindingData(prevout) {
   const unblindedInputBlindingData = {
-    value: confidential.confidentialValueToSatoshi(prevout.value).toString(10),
-    ag: prevout.asset.slice(1),
-    abf: transaction_1.ZERO,
-    vbf: transaction_1.ZERO,
+    satoshis: confidential.confidentialValueToSatoshi(prevout.value),
+    amountBlinder: transaction_1.ZERO.toString('hex'),
+    asset: prevout.asset.slice(1).toString('hex'),
+    assetBlinder: transaction_1.ZERO.toString('hex'),
   };
   return unblindedInputBlindingData;
 }
-function unblindWitnessUtxo(prevout, blindingPrivKey) {
+function getBlindedWitnessUtxoBlindingData(prevout, blindingPrivKey) {
   const unblindProof = confidential.unblindOutput(
     prevout.nonce,
     blindingPrivKey,
@@ -1412,9 +1463,9 @@ function unblindWitnessUtxo(prevout, blindingPrivKey) {
     prevout.script,
   );
   return {
-    value: unblindProof.value,
-    ag: unblindProof.asset,
-    abf: unblindProof.assetBlindingFactor,
-    vbf: unblindProof.valueBlindingFactor,
+    satoshis: parseInt(unblindProof.value, 10),
+    amountBlinder: unblindProof.valueBlindingFactor.toString('hex'),
+    asset: unblindProof.asset.toString('hex'),
+    assetBlinder: unblindProof.assetBlindingFactor.toString('hex'),
   };
 }

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -1445,6 +1445,7 @@ function toBlindingData(blindDataLike, witnessUtxo) {
   }
   return blindDataLike;
 }
+exports.toBlindingData = toBlindingData;
 function randomBlinder() {
   return randomBytes().toString('hex');
 }

--- a/test/confidential.spec.ts
+++ b/test/confidential.spec.ts
@@ -1,3 +1,4 @@
+import { WitnessUtxo } from 'bip174/src/lib/interfaces';
 import * as assert from 'assert';
 import { describe, it } from 'mocha';
 import * as confidential from '../src/confidential';
@@ -62,13 +63,16 @@ describe('confidential', () => {
 
   it('unblind', () => {
     fixtures.valid.unblind.forEach((f: any) => {
-      const unblindProof = confidential.unblindOutput(
-        f.ephemeralPubkey,
+      const out: WitnessUtxo = {
+        value: f.valueCommitment,
+        asset: f.assetGenerator,
+        script: f.scriptPubkey,
+        rangeProof: f.rangeproof,
+        nonce: f.ephemeralPubkey,
+      };
+      const unblindProof = confidential.unblindOutputWithKey(
+        out,
         f.blindingPrivkey,
-        f.rangeproof,
-        f.valueCommitment,
-        f.assetGenerator,
-        f.scriptPubkey,
       );
       assert.strictEqual(unblindProof.value, f.expected.value);
       assert.strictEqual(

--- a/test/confidential.spec.ts
+++ b/test/confidential.spec.ts
@@ -1,8 +1,10 @@
-import { WitnessUtxo } from 'bip174/src/lib/interfaces';
 import * as assert from 'assert';
-import { describe, it } from 'mocha';
 import * as confidential from '../src/confidential';
 import * as preFixtures from './fixtures/confidential.json';
+
+import { describe, it } from 'mocha';
+
+import { TxOutput } from '../ts_src/index';
 
 const initBuffers = (object: any): typeof preFixtures =>
   JSON.parse(JSON.stringify(object), (_, value) => {
@@ -63,7 +65,7 @@ describe('confidential', () => {
 
   it('unblind', () => {
     fixtures.valid.unblind.forEach((f: any) => {
-      const out: WitnessUtxo = {
+      const out: TxOutput = {
         value: f.valueCommitment,
         asset: f.assetGenerator,
         script: f.scriptPubkey,

--- a/test/integration/transaction.spec.ts
+++ b/test/integration/transaction.spec.ts
@@ -6,7 +6,10 @@ import { networks as NETWORKS } from '../..';
 import * as regtestUtils from './_regtest';
 const rng = require('randombytes');
 const { regtest } = NETWORKS;
-const { satoshiToConfidentialValue, unblindWitnessUtxo } = liquid.confidential;
+const {
+  satoshiToConfidentialValue,
+  unblindOutputWithKey,
+} = liquid.confidential;
 
 // See bottom of file for some helper functions used to make the payment objects needed.
 
@@ -708,7 +711,7 @@ describe('liquidjs-lib (transactions with psbt)', () => {
         'noredeem',
       );
 
-      const inputBlindingData = unblindWitnessUtxo(
+      const inputBlindingData = unblindOutputWithKey(
         inputDataConfidential.witnessUtxo,
         aliceBlindingPrivateKey,
       );

--- a/test/integration/transaction.spec.ts
+++ b/test/integration/transaction.spec.ts
@@ -6,7 +6,7 @@ import { networks as NETWORKS } from '../..';
 import * as regtestUtils from './_regtest';
 const rng = require('randombytes');
 const { regtest } = NETWORKS;
-const { satoshiToConfidentialValue } = liquid.confidential;
+const { satoshiToConfidentialValue, unblindWitnessUtxo } = liquid.confidential;
 
 // See bottom of file for some helper functions used to make the payment objects needed.
 
@@ -673,6 +673,81 @@ describe('liquidjs-lib (transactions with psbt)', () => {
 
       assert.strictEqual(psbt.validateSignaturesOfInput(0), true);
       assert.strictEqual(psbt.validateSignaturesOfInput(1), true);
+
+      psbt.finalizeAllInputs();
+
+      // build and broadcast our RegTest network
+      await regtestUtils.broadcast(psbt.extractTransaction().toHex());
+    },
+  );
+
+  it(
+    'can create (and broadcast via 3PBP) a confidential Transaction' +
+      ' using blinders',
+    async () => {
+      // these are { payment: Payment; keys: ECPair[] }
+      const alicePaymentConfidential = createPayment(
+        'p2wpkh',
+        undefined,
+        undefined,
+        true,
+      ); // confidential
+
+      const bobPayment = createPayment('p2pkh', undefined, undefined, false); // unconfidential
+
+      const aliceBlindingPubKey = liquid.ECPair.fromPrivateKey(
+        alicePaymentConfidential.blindingKeys[0],
+      ).publicKey!;
+
+      const aliceBlindingPrivateKey: Buffer =
+        alicePaymentConfidential.blindingKeys[0];
+
+      const inputDataConfidential = await getInputData(
+        alicePaymentConfidential.payment,
+        true,
+        'noredeem',
+      );
+
+      const inputBlindingData = unblindWitnessUtxo(
+        inputDataConfidential.witnessUtxo,
+        aliceBlindingPrivateKey,
+      );
+
+      // network is only needed if you pass an address to addOutput
+      // using script (Buffer of scriptPubkey) instead will avoid needed network.
+      const psbt = new liquid.Psbt({ network: regtest })
+        .addInput(inputDataConfidential) // alice unspent (confidential)
+        .addOutput({
+          asset,
+          nonce,
+          script: bobPayment.payment.output,
+          value: satoshiToConfidentialValue(1000),
+        }) // the actual spend to bob
+        .addOutput({
+          asset,
+          nonce,
+          script: alicePaymentConfidential.payment.output,
+          value: satoshiToConfidentialValue(99991000),
+        }) // Alice's change
+        .addOutput({
+          asset,
+          nonce,
+          script: alicePaymentConfidential.payment.output,
+          value: satoshiToConfidentialValue(1000),
+        }) // Alice's change bis (need two blind outputs)
+        .addOutput({
+          asset,
+          nonce,
+          script: Buffer.alloc(0),
+          value: satoshiToConfidentialValue(7000),
+        }) // fees in Liquid are explicit
+        .blindOutputsByIndex(
+          new Map().set(0, inputBlindingData),
+          new Map().set(1, aliceBlindingPubKey).set(2, aliceBlindingPubKey),
+        )
+        .signInput(0, alicePaymentConfidential.keys[0]);
+
+      assert.strictEqual(psbt.validateSignaturesOfInput(0), true);
 
       psbt.finalizeAllInputs();
 

--- a/test/psbt.spec.ts
+++ b/test/psbt.spec.ts
@@ -155,9 +155,6 @@ describe('Psbt', () => {
       const decodedTx = Psbt.fromBase64(encodedBase64Tx);
       const decodedWitnessUtxo = decodedTx.data.inputs[0].witnessUtxo;
 
-      // console.log(witnessUtxo);
-      // console.log(decodedWitnessUtxo);
-
       assert.deepStrictEqual(decodedWitnessUtxo, witnessUtxo);
     });
   });

--- a/ts_src/confidential.ts
+++ b/ts_src/confidential.ts
@@ -3,7 +3,13 @@ import * as secp256k1 from 'secp256k1-zkp';
 
 import * as bufferutils from './bufferutils';
 import * as crypto from './crypto';
-import { BlindingData } from './psbt';
+
+export interface BlindingData {
+  satoshis: number;
+  amountBlinder: string;
+  asset: string;
+  assetBlinder: string;
+}
 
 function nonceHash(pubkey: Buffer, privkey: Buffer): Buffer {
   return crypto.sha256(secp256k1.ecdh.ecdh(pubkey, privkey));

--- a/ts_src/confidential.ts
+++ b/ts_src/confidential.ts
@@ -51,24 +51,24 @@ export interface UnblindOutputResult {
 }
 
 export function unblindOutputWithKey(
-  prevout: Output,
+  out: Output,
   blindingPrivKey: Buffer,
 ): UnblindOutputResult {
-  const nonce = nonceHash(prevout.nonce, blindingPrivKey);
-  return unblindOutputWithNonce(prevout, nonce);
+  const nonce = nonceHash(out.nonce, blindingPrivKey);
+  return unblindOutputWithNonce(out, nonce);
 }
 
 export function unblindOutputWithNonce(
-  prevout: Output,
+  out: Output,
   nonce: Buffer,
 ): UnblindOutputResult {
-  const gen = secp256k1.generator.parse(prevout.asset);
+  const gen = secp256k1.generator.parse(out.asset);
   const { value, blindFactor, message } = secp256k1.rangeproof.rewind(
-    prevout.value,
-    prevout.rangeProof!,
+    out.value,
+    out.rangeProof!,
     nonce,
     gen,
-    prevout.script,
+    out.script,
   );
 
   return {

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -1819,7 +1819,7 @@ export function toBlindingData(
 
   if (Buffer.isBuffer(blindDataLike)) {
     if (!witnessUtxo) throw new Error('need witnessUtxo');
-    return confidential.unblindWitnessUtxo(witnessUtxo, blindDataLike);
+    return confidential.unblindOutputWithKey(witnessUtxo, blindDataLike);
   }
 
   return blindDataLike as confidential.BlindingData;

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -1808,7 +1808,7 @@ export function computeOutputsBlindingData(
   return outputsBlindingData;
 }
 
-function toBlindingData(
+export function toBlindingData(
   blindDataLike: BlindingDataLike,
   witnessUtxo?: WitnessUtxo,
 ): confidential.BlindingData {

--- a/tslint.json
+++ b/tslint.json
@@ -21,6 +21,7 @@
     "no-var-requires": false,
     "no-unused-expression": false,
     "object-literal-sort-keys": false,
+    "ordered-imports": false,
     "quotemark": [true, "single", "avoid-escape"],
     "typedef": [
       true,

--- a/types/confidential.d.ts
+++ b/types/confidential.d.ts
@@ -8,8 +8,8 @@ export interface UnblindOutputResult {
     asset: Buffer;
     assetBlindingFactor: Buffer;
 }
-export declare function unblindOutputWithKey(prevout: Output, blindingPrivKey: Buffer): UnblindOutputResult;
-export declare function unblindOutputWithNonce(prevout: Output, nonce: Buffer): UnblindOutputResult;
+export declare function unblindOutputWithKey(out: Output, blindingPrivKey: Buffer): UnblindOutputResult;
+export declare function unblindOutputWithNonce(out: Output, nonce: Buffer): UnblindOutputResult;
 export interface RangeProofInfoResult {
     ctExp: number;
     ctBits: number;

--- a/types/confidential.d.ts
+++ b/types/confidential.d.ts
@@ -15,7 +15,8 @@ export interface UnblindOutputResult {
     assetBlindingFactor: Buffer;
 }
 export declare function unblindOutput(ephemeralPubkey: Buffer, blindingPrivkey: Buffer, rangeproof: Buffer, valueCommit: Buffer, asset: Buffer, scriptPubkey: Buffer): UnblindOutputResult;
-export declare function unblindWitnessUtxo(prevout: WitnessUtxo, blindingPrivKey: Buffer): BlindingData;
+export declare function unblindOutputWithKey(prevout: WitnessUtxo, blindingPrivKey: Buffer): BlindingData;
+export declare function unblindOutputWithNonce(prevout: WitnessUtxo, nonce: Buffer): BlindingData;
 export interface RangeProofInfoResult {
     ctExp: number;
     ctBits: number;

--- a/types/confidential.d.ts
+++ b/types/confidential.d.ts
@@ -1,10 +1,4 @@
-import { WitnessUtxo } from 'bip174/src/lib/interfaces';
-export interface BlindingData {
-    satoshis: number;
-    amountBlinder: string;
-    asset: string;
-    assetBlinder: string;
-}
+import { Output } from './transaction';
 export declare function valueBlindingFactor(inValues: string[], outValues: string[], inGenerators: Buffer[], outGenerators: Buffer[], inFactors: Buffer[], outFactors: Buffer[]): Buffer;
 export declare function valueCommitment(value: string, generator: Buffer, factor: Buffer): Buffer;
 export declare function assetCommitment(asset: Buffer, factor: Buffer): Buffer;
@@ -14,9 +8,8 @@ export interface UnblindOutputResult {
     asset: Buffer;
     assetBlindingFactor: Buffer;
 }
-export declare function unblindOutput(ephemeralPubkey: Buffer, blindingPrivkey: Buffer, rangeproof: Buffer, valueCommit: Buffer, asset: Buffer, scriptPubkey: Buffer): UnblindOutputResult;
-export declare function unblindOutputWithKey(prevout: WitnessUtxo, blindingPrivKey: Buffer): BlindingData;
-export declare function unblindOutputWithNonce(prevout: WitnessUtxo, nonce: Buffer): BlindingData;
+export declare function unblindOutputWithKey(prevout: Output, blindingPrivKey: Buffer): UnblindOutputResult;
+export declare function unblindOutputWithNonce(prevout: Output, nonce: Buffer): UnblindOutputResult;
 export interface RangeProofInfoResult {
     ctExp: number;
     ctBits: number;

--- a/types/confidential.d.ts
+++ b/types/confidential.d.ts
@@ -1,3 +1,5 @@
+import { WitnessUtxo } from 'bip174/src/lib/interfaces';
+import { BlindingData } from './psbt';
 export declare function valueBlindingFactor(inValues: string[], outValues: string[], inGenerators: Buffer[], outGenerators: Buffer[], inFactors: Buffer[], outFactors: Buffer[]): Buffer;
 export declare function valueCommitment(value: string, generator: Buffer, factor: Buffer): Buffer;
 export declare function assetCommitment(asset: Buffer, factor: Buffer): Buffer;
@@ -8,6 +10,7 @@ export interface UnblindOutputResult {
     assetBlindingFactor: Buffer;
 }
 export declare function unblindOutput(ephemeralPubkey: Buffer, blindingPrivkey: Buffer, rangeproof: Buffer, valueCommit: Buffer, asset: Buffer, scriptPubkey: Buffer): UnblindOutputResult;
+export declare function unblindWitnessUtxo(prevout: WitnessUtxo, blindingPrivKey: Buffer): BlindingData;
 export interface RangeProofInfoResult {
     ctExp: number;
     ctBits: number;

--- a/types/confidential.d.ts
+++ b/types/confidential.d.ts
@@ -1,5 +1,10 @@
 import { WitnessUtxo } from 'bip174/src/lib/interfaces';
-import { BlindingData } from './psbt';
+export interface BlindingData {
+    satoshis: number;
+    amountBlinder: string;
+    asset: string;
+    assetBlinder: string;
+}
 export declare function valueBlindingFactor(inValues: string[], outValues: string[], inGenerators: Buffer[], outGenerators: Buffer[], inFactors: Buffer[], outFactors: Buffer[]): Buffer;
 export declare function valueCommitment(value: string, generator: Buffer, factor: Buffer): Buffer;
 export declare function assetCommitment(asset: Buffer, factor: Buffer): Buffer;

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -1,5 +1,5 @@
 import { Psbt as PsbtBase } from 'bip174';
-import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput } from 'bip174/src/lib/interfaces';
+import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput, WitnessUtxo } from 'bip174/src/lib/interfaces';
 import { Signer, SignerAsync } from './ecpair';
 import { Network } from './networks';
 import { Transaction } from './transaction';
@@ -134,4 +134,19 @@ interface HDSignerAsync extends HDSignerBase {
 interface RngOpts {
     rng?(arg0: number): Buffer;
 }
+export interface BlindingData {
+    satoshis: number;
+    amountBlinder: string;
+    asset: string;
+    assetBlinder: string;
+}
+export declare type BlindingDataLike = Buffer | BlindingData | undefined;
+/**
+ * Compute outputs blinders
+ * @param inputsBlindingData the transaction inputs blinding data
+ * @param outputsData data = [satoshis, asset] of output to blind
+ * @returns an array of BlindingData[] corresponding of blinders to blind outputs specified in outputsData
+ */
+export declare function computeOutputsBlindingData(inputsBlindingData: BlindingData[], outputsData: Array<[number, string]>): BlindingData[];
+export declare function toBlindingData(blindDataLike: BlindingDataLike, witnessUtxo?: WitnessUtxo): BlindingData;
 export {};

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -1,5 +1,6 @@
 import { Psbt as PsbtBase } from 'bip174';
-import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput, WitnessUtxo } from 'bip174/src/lib/interfaces';
+import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput } from 'bip174/src/lib/interfaces';
+import * as confidential from './confidential';
 import { Signer, SignerAsync } from './ecpair';
 import { Network } from './networks';
 import { Transaction } from './transaction';
@@ -134,19 +135,12 @@ interface HDSignerAsync extends HDSignerBase {
 interface RngOpts {
     rng?(arg0: number): Buffer;
 }
-export interface BlindingData {
-    satoshis: number;
-    amountBlinder: string;
-    asset: string;
-    assetBlinder: string;
-}
-export declare type BlindingDataLike = Buffer | BlindingData | undefined;
+export declare type BlindingDataLike = Buffer | confidential.BlindingData | undefined;
 /**
  * Compute outputs blinders
  * @param inputsBlindingData the transaction inputs blinding data
  * @param outputsData data = [satoshis, asset] of output to blind
  * @returns an array of BlindingData[] corresponding of blinders to blind outputs specified in outputsData
  */
-export declare function computeOutputsBlindingData(inputsBlindingData: BlindingData[], outputsData: Array<[number, string]>): BlindingData[];
-export declare function toBlindingData(blindDataLike: BlindingDataLike, witnessUtxo?: WitnessUtxo): BlindingData;
+export declare function computeOutputsBlindingData(inputsBlindingData: confidential.BlindingData[], outputsData: Array<[number, string]>): confidential.BlindingData[];
 export {};

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -75,8 +75,8 @@ export declare class Psbt {
     updateGlobal(updateData: PsbtGlobalUpdate): this;
     updateInput(inputIndex: number, updateData: PsbtInputUpdate): this;
     updateOutput(outputIndex: number, updateData: PsbtOutputUpdate): this;
-    blindOutputs(blindingPrivkeys: Buffer[], blindingPubkeys: Buffer[], opts?: RngOpts): this;
-    blindOutputsByIndex(inputsBlindingPrivKeys: Map<number, Buffer>, outputsBlindingPubKeys: Map<number, Buffer>, opts?: RngOpts): this;
+    blindOutputs(blindingDataLike: BlindingDataLike[], blindingPubkeys: Buffer[], opts?: RngOpts): this;
+    blindOutputsByIndex(inputsBlindingData: Map<number, BlindingDataLike>, outputsBlindingPubKeys: Map<number, Buffer>, opts?: RngOpts): this;
     addUnknownKeyValToGlobal(keyVal: KeyValue): this;
     addUnknownKeyValToInput(inputIndex: number, keyVal: KeyValue): this;
     addUnknownKeyValToOutput(outputIndex: number, keyVal: KeyValue): this;

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -135,13 +135,18 @@ interface HDSignerAsync extends HDSignerBase {
 interface RngOpts {
     rng?(arg0: number): Buffer;
 }
-export declare type BlindingDataLike = Buffer | confidential.BlindingData | undefined;
+export declare type BlindingDataLike = Buffer | confidential.UnblindOutputResult | undefined;
 /**
  * Compute outputs blinders
  * @param inputsBlindingData the transaction inputs blinding data
- * @param outputsData data = [satoshis, asset] of output to blind
+ * @param outputsData data = [satoshis, asset] of output to blind ([string Buffer])
  * @returns an array of BlindingData[] corresponding of blinders to blind outputs specified in outputsData
  */
-export declare function computeOutputsBlindingData(inputsBlindingData: confidential.BlindingData[], outputsData: Array<[number, string]>): confidential.BlindingData[];
-export declare function toBlindingData(blindDataLike: BlindingDataLike, witnessUtxo?: WitnessUtxo): confidential.BlindingData;
+export declare function computeOutputsBlindingData(inputsBlindingData: confidential.UnblindOutputResult[], outputsData: Array<[string, Buffer]>): confidential.UnblindOutputResult[];
+/**
+ * toBlindingData convert a BlindingDataLike to UnblindOutputResult
+ * @param blindDataLike blinding data "like" associated to a specific input I
+ * @param witnessUtxo the prevout of the input I
+ */
+export declare function toBlindingData(blindDataLike: BlindingDataLike, witnessUtxo?: WitnessUtxo): confidential.UnblindOutputResult;
 export {};

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -1,5 +1,5 @@
 import { Psbt as PsbtBase } from 'bip174';
-import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput } from 'bip174/src/lib/interfaces';
+import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput, WitnessUtxo } from 'bip174/src/lib/interfaces';
 import * as confidential from './confidential';
 import { Signer, SignerAsync } from './ecpair';
 import { Network } from './networks';
@@ -143,4 +143,5 @@ export declare type BlindingDataLike = Buffer | confidential.BlindingData | unde
  * @returns an array of BlindingData[] corresponding of blinders to blind outputs specified in outputsData
  */
 export declare function computeOutputsBlindingData(inputsBlindingData: confidential.BlindingData[], outputsData: Array<[number, string]>): confidential.BlindingData[];
+export declare function toBlindingData(blindDataLike: BlindingDataLike, witnessUtxo?: WitnessUtxo): confidential.BlindingData;
 export {};


### PR DESCRIPTION
**This PR adds `BlindingData` interface and handle it as an argument in `rawBlindOutputs`**

- `blindOutputs` & `blindOutputsByIndex` accepts now `BlindingDataLike` instead of Private blinding key
- `BlindingDataLike` = `BlindingData` OR `Buffer` (blinding private key) OR undefined for unconfidential input (optional in this case).
- This PR **does not break the former code**, you are able to use blinding private keys as `BlindingDataLike`.
- `rawBlindOutputs` will converts `BlindingDataLike` to `BlindingData` and use them to compute outputs' blinding data (see `computeOutputsBlindingData` function).
- `unblindWitnessUtxo` is a new exported function in `confidential` (we could use it to get `BlindingData` from `WitnessUtxo + blindPrivKey`).
- add a test case in `integration/transaction.spec.ts`

it closes #9 

@tiero @altafan please review