### PR TITLE
[WIP] Fix issuance size calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Run Nigiri
         uses: vulpemventures/nigiri-github-action@v1
 
+      - name: Sleep for 5 seconds
+        run: sleep 5s
+        shell: bash
+
       - name: Install dependencies
         run: npm install --ci
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -392,7 +392,7 @@ class Transaction {
               txIn.issuance.assetEntropy.length +
               txIn.issuance.assetAmount.length +
               txIn.issuance.tokenAmount.length
-            : sum, // we'll use the empty 00 Buffer if issuance is not set
+            : sum + 1, // we'll use the empty 00 Buffer if issuance is not set
         0,
       );
     }

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -491,7 +491,7 @@ export class Transaction {
               txIn.issuance!.assetEntropy.length +
               txIn.issuance!.assetAmount.length +
               txIn.issuance!.tokenAmount.length
-            : sum, // we'll use the empty 00 Buffer if issuance is not set
+            : sum + 1, // we'll use the empty 00 Buffer if issuance is not set
         0,
       );
     }


### PR DESCRIPTION
If an input doesn't have an `issuance` field, a `00` Buffer is written to `tBuffer`, which is used to calculate the `hashIssuances`. However the buffer size is not incremented by 1.


