### PR TITLE
Add `testnet` network object

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -172,14 +172,18 @@ exports.toOutputScript = toOutputScript;
 function isNetwork(network, address) {
   if (address.startsWith(network.blech32) || address.startsWith(network.bech32))
     return true;
-  const payload = bs58check_1.default.decode(address);
-  const prefix = payload.readUInt8(0);
-  if (
-    prefix === network.confidentialPrefix ||
-    prefix === network.pubKeyHash ||
-    prefix === network.scriptHash
-  )
-    return true;
+  try {
+    const payload = bs58check_1.default.decode(address);
+    const prefix = payload.readUInt8(0);
+    if (
+      prefix === network.confidentialPrefix ||
+      prefix === network.pubKeyHash ||
+      prefix === network.scriptHash
+    )
+      return true;
+  } catch (_a) {
+    return false;
+  }
   return false;
 }
 // determines the network of a given address

--- a/src/address.js
+++ b/src/address.js
@@ -169,31 +169,25 @@ function toOutputScript(address, network) {
   throw new Error(address + ' has no matching Script');
 }
 exports.toOutputScript = toOutputScript;
-function getNetwork(address) {
-  if (
-    address.startsWith(networks.liquid.blech32) ||
-    address.startsWith(networks.liquid.bech32)
-  )
-    return networks.liquid;
-  if (
-    address.startsWith(networks.regtest.blech32) ||
-    address.startsWith(networks.regtest.bech32)
-  )
-    return networks.regtest;
+function isNetwork(network, address) {
+  if (address.startsWith(network.blech32) || address.startsWith(network.bech32))
+    return true;
   const payload = bs58check_1.default.decode(address);
   const prefix = payload.readUInt8(0);
   if (
-    prefix === networks.liquid.confidentialPrefix ||
-    prefix === networks.liquid.pubKeyHash ||
-    prefix === networks.liquid.scriptHash
+    prefix === network.confidentialPrefix ||
+    prefix === network.pubKeyHash ||
+    prefix === network.scriptHash
   )
-    return networks.liquid;
-  if (
-    prefix === networks.regtest.confidentialPrefix ||
-    prefix === networks.regtest.pubKeyHash ||
-    prefix === networks.regtest.scriptHash
-  )
-    return networks.regtest;
+    return true;
+  return false;
+}
+// determines the network of a given address
+function getNetwork(address) {
+  const allNetworks = [networks.liquid, networks.regtest, networks.testnet];
+  for (const network of allNetworks) {
+    if (isNetwork(network, address)) return network;
+  }
   throw new Error(address + ' has an invalid prefix');
 }
 exports.getNetwork = getNetwork;

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -93,7 +93,7 @@ function fromWIF(wifString, network) {
       })
       .pop();
     if (!network) throw new Error('Unknown network version');
-    // otherwise, assume a network object (or default to bitcoin)
+    // otherwise, assume a network object (or default to liquid)
   } else {
     network = network || NETWORKS.liquid;
     if (version !== network.wif) throw new Error('Invalid network version');

--- a/src/networks.js
+++ b/src/networks.js
@@ -28,3 +28,11 @@ exports.regtest = {
   confidentialPrefix: 4,
   assetHash: '5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225',
 };
+exports.testnet = Object.assign({}, exports.regtest, {
+  bech32: 'tex',
+  blech32: 'tlq',
+  pubKeyHash: 36,
+  scriptHash: 19,
+  confidentialPrefix: 23,
+  assetHash: '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49',
+});

--- a/src/payments/p2wpkh.js
+++ b/src/payments/p2wpkh.js
@@ -115,6 +115,7 @@ function p2wpkh(a, opts) {
   lazy.prop(o, 'confidentialAddress', () => {
     if (!o.address) return;
     if (!o.blindkey) return;
+    if (!o.network) return;
     const res = baddress.fromBech32(o.address);
     const data = Buffer.concat([
       Buffer.from([res.version, res.data.length]),

--- a/test/fixtures/address.json
+++ b/test/fixtures/address.json
@@ -53,6 +53,15 @@
       "bech32": "ert1qyny4kp4adanuu670vfrnz7t384s8gvdtnwr0jcvvrwqwar4t9qcs2m7c20",
       "script": "OP_0 24c95b06bd6f67ce6bcf62473179713d607431ab9b86f9618c1b80ee8eab2831",
       "confidentialAddress": "el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqqfxftvrt6mm8ee4u7cj8x9uhz0tqwsc6hxuxl9sccxuqa682k2p34j69q77djwvn"
+    },
+    {
+      "network": "testnet",
+      "version": 0,
+      "blindkey": "0339b93f60bf024de61e56a0d0be0df864b952f4c82d2ed725fdb5d5991d5c4352",
+      "data": "e45427947dd5a21ee6678f10f22b10eaa26e5a5d",
+      "bech32": "tex1qu32z09ra6k3paen83ug0y2csa23xukja3fyeyx",
+      "script": "OP_0 e45427947dd5a21ee6678f10f22b10eaa26e5a5d",
+      "confidentialAddress": "tlq1qqvumj0mqhupymes726sdp0sdlpjtj5h5eqkja4e9lk6atxgat3p49ez5y728m4dzrmnx0rcs7g43p64zded96r7etwq8lmd2e"
     }
   ],
   "bech32": [

--- a/testnet.js
+++ b/testnet.js
@@ -1,0 +1,4 @@
+const { networks, ECPair } = require('./src')
+
+
+const ecPair = ECPair

--- a/testnet.js
+++ b/testnet.js
@@ -1,4 +1,0 @@
-const { networks, ECPair } = require('./src')
-
-
-const ecPair = ECPair

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -207,33 +207,31 @@ export function toOutputScript(address: string, network?: Network): Buffer {
   throw new Error(address + ' has no matching Script');
 }
 
-export function getNetwork(address: string): Network {
+function isNetwork(network: Network, address: string): boolean {
   if (
-    address.startsWith(networks.liquid.blech32) ||
-    address.startsWith(networks.liquid.bech32)
-  )
-    return networks.liquid;
-  if (
-    address.startsWith(networks.regtest.blech32) ||
-    address.startsWith(networks.regtest.bech32)
-  )
-    return networks.regtest;
+    address.startsWith(network.blech32) ||
+    address.startsWith(network.bech32)
+  ) return true;
 
   const payload = bs58check.decode(address);
   const prefix = payload.readUInt8(0);
 
   if (
-    prefix === networks.liquid.confidentialPrefix ||
-    prefix === networks.liquid.pubKeyHash ||
-    prefix === networks.liquid.scriptHash
-  )
-    return networks.liquid;
-  if (
-    prefix === networks.regtest.confidentialPrefix ||
-    prefix === networks.regtest.pubKeyHash ||
-    prefix === networks.regtest.scriptHash
-  )
-    return networks.regtest;
+    prefix === network.confidentialPrefix ||
+    prefix === network.pubKeyHash ||
+    prefix === network.scriptHash
+  ) return true;
+
+  return false;
+}
+
+// determines the network of a given address
+export function getNetwork(address: string): Network {
+  const allNetworks = [networks.liquid, networks.regtest, networks.testnet];
+
+  for (const network of allNetworks) {
+    if (isNetwork(network, address)) return network;
+  }
 
   throw new Error(address + ' has an invalid prefix');
 }

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -208,19 +208,22 @@ export function toOutputScript(address: string, network?: Network): Buffer {
 }
 
 function isNetwork(network: Network, address: string): boolean {
-  if (
-    address.startsWith(network.blech32) ||
-    address.startsWith(network.bech32)
-  ) return true;
+  if (address.startsWith(network.blech32) || address.startsWith(network.bech32))
+    return true;
 
-  const payload = bs58check.decode(address);
-  const prefix = payload.readUInt8(0);
+  try {
+    const payload = bs58check.decode(address);
+    const prefix = payload.readUInt8(0);
 
-  if (
-    prefix === network.confidentialPrefix ||
-    prefix === network.pubKeyHash ||
-    prefix === network.scriptHash
-  ) return true;
+    if (
+      prefix === network.confidentialPrefix ||
+      prefix === network.pubKeyHash ||
+      prefix === network.scriptHash
+    )
+      return true;
+  } catch {
+    return false;
+  }
 
   return false;
 }

--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -130,7 +130,7 @@ function fromWIF(wifString: string, network?: Network | Network[]): ECPair {
 
     if (!network) throw new Error('Unknown network version');
 
-    // otherwise, assume a network object (or default to bitcoin)
+    // otherwise, assume a network object (or default to liquid)
   } else {
     network = network || NETWORKS.liquid;
 

--- a/ts_src/networks.ts
+++ b/ts_src/networks.ts
@@ -31,6 +31,7 @@ export const liquid: Network = {
   confidentialPrefix: 12,
   assetHash: '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d',
 };
+
 export const regtest: Network = {
   messagePrefix: '\x18Liquid Signed Message:\n',
   bech32: 'ert',
@@ -44,4 +45,14 @@ export const regtest: Network = {
   wif: 0xef,
   confidentialPrefix: 4,
   assetHash: '5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225',
+};
+
+export const testnet: Network = {
+  ...regtest,
+  bech32: 'tex',
+  blech32: 'tlq',
+  pubKeyHash: 36,
+  scriptHash: 19,
+  confidentialPrefix: 23,
+  assetHash: '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49',
 };

--- a/ts_src/payments/p2wpkh.ts
+++ b/ts_src/payments/p2wpkh.ts
@@ -60,7 +60,7 @@ export function p2wpkh(a: Payment, opts?: PaymentOpts): Payment {
       unconfidentialAddress: baddress.toBech32(
         result.data.slice(2),
         result.version,
-        network!.bech32,
+        network.bech32,
       ),
     };
   });
@@ -112,12 +112,13 @@ export function p2wpkh(a: Payment, opts?: PaymentOpts): Payment {
   lazy.prop(o, 'confidentialAddress', () => {
     if (!o.address) return;
     if (!o.blindkey) return;
+    if (!o.network) return;
     const res = baddress.fromBech32(o.address);
     const data = Buffer.concat([
       Buffer.from([res.version, res.data.length]),
       res.data,
     ]);
-    return baddress.toBlech32(data, o.blindkey!, o.network!.blech32);
+    return baddress.toBlech32(data, o.blindkey!, o.network.blech32);
   });
 
   // extended validation

--- a/types/networks.d.ts
+++ b/types/networks.d.ts
@@ -15,4 +15,5 @@ interface Bip32 {
 }
 export declare const liquid: Network;
 export declare const regtest: Network;
+export declare const testnet: Network;
 export {};


### PR DESCRIPTION
This PR adds the `testnet` network object in `networks.ts`, and adds a _testnet address_ fixture. Also, it rewrites the `getNetwork` function (support testnet).

it closes #29 

@tiero please review