### PR TITLE
Fix isssuance contract hash calculation 

### DIFF
--- a/src/issuance.js
+++ b/src/issuance.js
@@ -40,7 +40,17 @@ exports.validateIssuanceContract = validateIssuanceContract;
 function hashContract(contract) {
   if (!validateIssuanceContract(contract))
     throw new Error('Invalid asset contract');
-  return bcrypto.sha256(Buffer.from(JSON.stringify(contract)));
+  const constractJSON = `{"entity":{"domain":"${
+    contract.entity.domain
+  }"},"issuer_pubkey":"${contract.issuer_pubkey}","name":"${
+    contract.name
+  }","precision":${contract.precision},"ticker":"${
+    contract.ticker
+  }","version":${contract.version}}`;
+  return bcrypto
+    .sha256(Buffer.from(constractJSON))
+    .slice()
+    .reverse();
 }
 exports.hashContract = hashContract;
 /**

--- a/test/fixtures/contract_hash.json
+++ b/test/fixtures/contract_hash.json
@@ -1,0 +1,41 @@
+[
+  {
+    "contractJSON": {
+      "entity": {
+        "domain": "acecoin.cash"
+      },
+      "issuer_pubkey": "03373f83e102bd7fbf4e1e53447f879a6d2b32070900f1a60d72a487afe5364c2a",
+      "name": "ACE Coin",
+      "precision": 0,
+      "ticker": "ACE",
+      "version": 0
+    },
+    "contractHash": "2d9d310ab7885463357382856ec91c7f586b4d2dabfac23849c66aef3d378310"
+  },
+  {
+    "contractJSON": {
+      "entity": {
+        "domain": "liquid.beer"
+      },
+      "issuer_pubkey": "02436437ab5ecb6966b7dea1333fad14a658ae185d8ced00aa598af5997b55cd24",
+      "name": "Double malt pint",
+      "precision": 2,
+      "ticker": "DMp",
+      "version": 0
+      }, 
+      "contractHash": "459f2f4eb63d5cf6a4d1f8e54d3d5edb2245df63bd97e774864505c17ee188d8"
+  },
+  {
+    "contractJSON": {
+      "entity": {
+        "domain": "exordium.co"
+      },
+      "issuer_pubkey": "028ff1586cb9e862f8704f51c8c02eb1c708d1c0316b8fb563f72aa652db85e9bf",
+      "name": "EXO Token",
+      "precision": 0,
+      "ticker": "EXO",
+      "version": 0
+    },
+    "contractHash": "86ddc3aeda751fb86e2c074c05e4a7ef9253f030ee2c55de0ee35e1b2afec49c"
+  }
+]

--- a/test/integration/issuances.spec.ts
+++ b/test/integration/issuances.spec.ts
@@ -57,6 +57,7 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
         precision: 8,
         blindedIssuance: true, // must be true, we'll blind the issuance!
         contract: {
+          issuer_pubkey: '0000',
           name: 'testcoin',
           ticker: 'T-COIN',
           entity: {
@@ -124,6 +125,7 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
       tokenAmount: 1,
       precision: 8,
       contract: {
+        issuer_pubkey: '0000',
         name: 'testcoin-bis',
         ticker: 'T-COI',
         entity: {
@@ -177,6 +179,7 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
       tokenAmount: 1,
       precision: 8,
       contract: {
+        issuer_pubkey: '0000',
         name: 'testcoin-bis',
         ticker: 'T-COI',
         entity: {
@@ -240,6 +243,7 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
         precision: 8,
         blindedIssuance: true, // must be true, we'll blind the issuance!
         contract: {
+          issuer_pubkey: '0000',
           name: 'testcoin',
           ticker: 'T-COIN',
           entity: {

--- a/test/issuance.spec.ts
+++ b/test/issuance.spec.ts
@@ -8,6 +8,7 @@ import { Transaction } from './../ts_src/transaction';
 import { ECPair, networks } from '../ts_src';
 import { satoshiToConfidentialValue } from './../ts_src/confidential';
 import * as fixtures from './fixtures/issuance.json';
+import contractFixtures from './fixtures/contract_hash.json';
 
 const typeforce = require('typeforce');
 
@@ -296,6 +297,20 @@ describe('Issuance', () => {
           expectedEntropy,
         );
       });
+    });
+
+    describe('contract hash calculation', () => {
+      for (const contractFixture of contractFixtures) {
+        it(`should calculate the correct contract hash for ${
+          contractFixture.contractJSON.name
+        }`, () => {
+          const computed = issuance.hashContract(contractFixture.contractJSON);
+          assert.strictEqual(
+            computed.toString('hex'),
+            contractFixture.contractHash,
+          );
+        });
+      }
     });
   });
 });

--- a/ts_src/issuance.ts
+++ b/ts_src/issuance.ts
@@ -13,11 +13,12 @@ export interface IssuanceEntity {
  * Ricardian asset contract.
  */
 export interface IssuanceContract {
+  entity: IssuanceEntity;
+  issuer_pubkey: string;
   name: string;
+  precision: number;
   ticker: string;
   version: number;
-  precision: number;
-  entity: IssuanceEntity;
 }
 
 /**
@@ -64,7 +65,17 @@ export function hashContract(contract: IssuanceContract): Buffer {
   if (!validateIssuanceContract(contract))
     throw new Error('Invalid asset contract');
 
-  return bcrypto.sha256(Buffer.from(JSON.stringify(contract)));
+  const constractJSON = `{"entity":{"domain":"${
+    contract.entity.domain
+  }"},"issuer_pubkey":"${contract.issuer_pubkey}","name":"${
+    contract.name
+  }","precision":${contract.precision},"ticker":"${
+    contract.ticker
+  }","version":${contract.version}}`;
+  return bcrypto
+    .sha256(Buffer.from(constractJSON))
+    .slice()
+    .reverse();
 }
 
 /**

--- a/types/issuance.d.ts
+++ b/types/issuance.d.ts
@@ -6,11 +6,12 @@ export interface IssuanceEntity {
  * Ricardian asset contract.
  */
 export interface IssuanceContract {
+    entity: IssuanceEntity;
+    issuer_pubkey: string;
     name: string;
+    precision: number;
     ticker: string;
     version: number;
-    precision: number;
-    entity: IssuanceEntity;
 }
 /**
  * An object describing an output point of the blockchain.


### PR DESCRIPTION
This PR add the `issuer_pubkey` member to the issuance contract and fixes the _contract hash computation_ (`hashContract` function):

1. Stop using `JSON.stringify` and build the JSON string manually instead (it ensures order of members and space between words).
2. reverse the bytes of the contract hash.
3. add `contract_hash.json` fixtures using real contracts from blockstream.info
4. add tests cases to ensure that we compute the same hashes of blockstream.info

@tiero please review

it closes #33 