### PR TITLE
Support non standard issuance contract fields + satoshis in `Add(Re)IssuanceArgs`

### DIFF
--- a/src/issuance.d.ts
+++ b/src/issuance.d.ts
@@ -13,6 +13,7 @@ export interface IssuanceContract {
     precision: number;
     ticker: string;
     version: number;
+    [key: string]: any;
 }
 /**
  * An object describing an output point of the blockchain.

--- a/src/issuance.d.ts
+++ b/src/issuance.d.ts
@@ -47,13 +47,12 @@ export declare function validateIssuanceContract(contract: IssuanceContract): bo
  */
 export declare function hashContract(contract: IssuanceContract): Buffer;
 /**
- * Returns an Issuance object for issuance transaction input.
- * @param assetAmount the number of asset to issue.
- * @param tokenAmount the number of token to issue.
- * @param precision the number of digit after the decimal point (8 for satoshi).
+ * Returns an unblinded Issuance object for issuance transaction input.
+ * @param assetSats the number of asset to issue.
+ * @param tokenSats the number of token to issue.
  * @param contract the asset ricarding contract of the issuance.
  */
-export declare function newIssuance(assetAmount: number, tokenAmount: number, precision?: number, contract?: IssuanceContract): Issuance;
+export declare function newIssuance(assetSats: number, tokenSats: number, contract?: IssuanceContract): Issuance;
 export declare function isReissuance(issuance: Issuance): boolean;
 /**
  * Generate the entropy.
@@ -78,14 +77,9 @@ export declare function calculateAsset(entropy: Buffer): Buffer;
  */
 export declare function calculateReissuanceToken(entropy: Buffer, confidential?: boolean): Buffer;
 /**
- * converts asset amount to confidential value.
+ * converts asset amount to satoshis.
+ * satoshis = assetAmount * 10^precision
  * @param assetAmount the asset amount.
- * @param precision the precision, 8 by default.
+ * @param precision the precision, 8 by default (like L-BTC).
  */
-export declare function toConfidentialAssetAmount(assetAmount: number, precision?: number): Buffer;
-/**
- * converts token amount to confidential value.
- * @param assetAmount the token amount.
- * @param precision the precision, 8 by default.
- */
-export declare function toConfidentialTokenAmount(tokenAmount: number, precision?: number): Buffer;
+export declare function amountWithPrecisionToSatoshis(assetAmount: number, precision?: number): number;

--- a/src/issuance.js
+++ b/src/issuance.js
@@ -74,15 +74,13 @@ exports.validateIssuanceContract = validateIssuanceContract;
 function hashContract(contract) {
   if (!validateIssuanceContract(contract))
     throw new Error('Invalid asset contract');
-  const constractJSON = `{"entity":{"domain":"${
-    contract.entity.domain
-  }"},"issuer_pubkey":"${contract.issuer_pubkey}","name":"${
-    contract.name
-  }","precision":${contract.precision},"ticker":"${
-    contract.ticker
-  }","version":${contract.version}}`;
+  const sortedKeys = Object.keys(contract).sort();
+  const sortedContract = sortedKeys.reduce(
+    (obj, key) => ({ ...obj, [key]: contract[key] }),
+    {},
+  );
   return bcrypto
-    .sha256(Buffer.from(constractJSON))
+    .sha256(Buffer.from(JSON.stringify(sortedContract)))
     .slice()
     .reverse();
 }

--- a/src/issuance.js
+++ b/src/issuance.js
@@ -92,12 +92,18 @@ exports.hashContract = hashContract;
  * @param contract the asset ricarding contract of the issuance.
  */
 function newIssuance(assetSats, tokenSats, contract) {
-  if (assetSats <= 0) throw new Error('Invalid asset amount');
+  if (assetSats < 0) throw new Error('Invalid asset amount');
   if (tokenSats < 0) throw new Error('Invalid token amount');
   const contractHash = contract ? hashContract(contract) : Buffer.alloc(32);
   const issuanceObject = {
-    assetAmount: (0, confidential_1.satoshiToConfidentialValue)(assetSats),
-    tokenAmount: (0, confidential_1.satoshiToConfidentialValue)(tokenSats),
+    assetAmount:
+      assetSats === 0
+        ? Buffer.of(0x00)
+        : (0, confidential_1.satoshiToConfidentialValue)(assetSats),
+    tokenAmount:
+      tokenSats === 0
+        ? Buffer.of(0x00)
+        : (0, confidential_1.satoshiToConfidentialValue)(tokenSats),
     assetBlindingNonce: Buffer.alloc(32),
     // in case of issuance, the asset entropy = the contract hash.
     assetEntropy: contractHash,

--- a/src/psbt.d.ts
+++ b/src/psbt.d.ts
@@ -9,7 +9,7 @@ import { Psbt as PsbtBase } from 'bip174-liquid';
 import { TinySecp256k1Interface } from 'ecpair';
 export interface AddIssuanceArgs {
     assetSats: number;
-    assetAddress: string;
+    assetAddress?: string;
     tokenSats: number;
     tokenAddress?: string;
     contract?: IssuanceContract;

--- a/src/psbt.d.ts
+++ b/src/psbt.d.ts
@@ -8,11 +8,10 @@ import { IssuanceBlindingKeys } from './types';
 import { Psbt as PsbtBase } from 'bip174-liquid';
 import { TinySecp256k1Interface } from 'ecpair';
 export interface AddIssuanceArgs {
-    assetAmount: number;
+    assetSats: number;
     assetAddress: string;
-    tokenAmount: number;
+    tokenSats: number;
     tokenAddress?: string;
-    precision: number;
     contract?: IssuanceContract;
     blindedIssuance?: boolean;
 }
@@ -22,11 +21,10 @@ export interface AddReissuanceArgs {
     nonWitnessUtxo?: NonWitnessUtxo;
     prevoutBlinder: Buffer;
     entropy: Buffer;
-    assetAmount: number;
+    assetSats: number;
     assetAddress: string;
-    tokenAmount: number;
+    tokenSats: number;
     tokenAddress: string;
-    precision: number;
     blindedIssuance?: boolean;
 }
 export interface TransactionInput {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,7 +10,7 @@ export declare function Signer(obj: any): boolean;
 export declare const ECPoint: any;
 export declare const Network: any;
 export interface IssuanceBlindingKeys {
-    assetKey: Buffer;
+    assetKey?: Buffer;
     tokenKey?: Buffer;
 }
 export declare const Buffer256bit: any;

--- a/test/fixtures/contract_hash.json
+++ b/test/fixtures/contract_hash.json
@@ -40,12 +40,11 @@
   },
   {
     "contractJSON": {
+      "name": "Attestato OIES #22",
       "entity": {
         "domain": "nft.siliconlake.it"
       },
-      "file": "QmSBt7nJMbHN6ndYGBbXj8FLCqdffnNRPbSu4oXLqV2p9E",
       "issuer_pubkey": "032707d05b6aa5e823956b5a0d83e5d1d2acd80e8d8d5a2833f3157f3604b0ef8d",
-      "name": "Attestato OIES #22",
       "nft": {
         "cid": "QmSpGmZqL9HHcDtT6xHBev6Uwj8hf2DfFJWJQAT2GTAT2p",
         "domain": "nft.siliconlake.it",
@@ -53,7 +52,8 @@
       },
       "precision": 0,
       "ticker": "OIE22",
-      "version": 0
+      "version": 0,
+      "file": "QmSBt7nJMbHN6ndYGBbXj8FLCqdffnNRPbSu4oXLqV2p9E"
     },
     "contractHash": "6c797254d3974813ed556220bfab10cb3a70ee3a5bd827b8f9525920ec6b3d6b"
   }

--- a/test/fixtures/contract_hash.json
+++ b/test/fixtures/contract_hash.json
@@ -37,5 +37,24 @@
       "version": 0
     },
     "contractHash": "86ddc3aeda751fb86e2c074c05e4a7ef9253f030ee2c55de0ee35e1b2afec49c"
+  },
+  {
+    "contractJSON": {
+      "entity": {
+        "domain": "nft.siliconlake.it"
+      },
+      "file": "QmSBt7nJMbHN6ndYGBbXj8FLCqdffnNRPbSu4oXLqV2p9E",
+      "issuer_pubkey": "032707d05b6aa5e823956b5a0d83e5d1d2acd80e8d8d5a2833f3157f3604b0ef8d",
+      "name": "Attestato OIES #22",
+      "nft": {
+        "cid": "QmSpGmZqL9HHcDtT6xHBev6Uwj8hf2DfFJWJQAT2GTAT2p",
+        "domain": "nft.siliconlake.it",
+        "hash": "38db66f3a5b7308fa06dc8396f4edc7dd0cf3c79f462eae2dca68e07b925d20c"
+      },
+      "precision": 0,
+      "ticker": "OIE22",
+      "version": 0
+    },
+    "contractHash": "6c797254d3974813ed556220bfab10cb3a70ee3a5bd827b8f9525920ec6b3d6b"
   }
 ]

--- a/test/integration/issuances.spec.ts
+++ b/test/integration/issuances.spec.ts
@@ -11,8 +11,8 @@ import {
 import { ECPair, ecc } from '../ecc';
 import { strictEqual } from 'assert';
 import {
+  amountWithPrecisionToSatoshis,
   issuanceEntropyFromInput,
-  toConfidentialTokenAmount,
 } from '../../ts_src/issuance';
 import { fromConfidential } from '../../ts_src/address';
 
@@ -52,9 +52,8 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
           tokenPay.payment.output,
           regtest,
         ),
-        assetAmount: 100,
-        tokenAmount: 1,
-        precision: 8,
+        assetSats: amountWithPrecisionToSatoshis(100),
+        tokenSats: amountWithPrecisionToSatoshis(1),
         blindedIssuance: true, // must be true, we'll blind the issuance!
         contract: {
           issuer_pubkey: '0000',
@@ -125,9 +124,8 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
     psbt.addIssuance({
       assetAddress: address.fromOutputScript(assetPay.payment.output, regtest),
       tokenAddress: address.fromOutputScript(tokenPay.payment.output, regtest),
-      assetAmount: 100,
-      tokenAmount: 1,
-      precision: 8,
+      assetSats: 100_0000_0000,
+      tokenSats: 1_0000_0000,
       contract: {
         issuer_pubkey: '0000',
         name: 'testcoin-bis',
@@ -183,9 +181,8 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
     psbt.addIssuance({
       assetAddress: address.fromOutputScript(assetPay.payment.output, regtest),
       tokenAddress: address.fromOutputScript(tokenPay.payment.output, regtest),
-      assetAmount: 100,
-      tokenAmount: 1,
-      precision: 8,
+      assetSats: 100_0000_0000,
+      tokenSats: 1_0000_0000,
       contract: {
         issuer_pubkey: '0000',
         name: 'testcoin-bis',
@@ -248,9 +245,8 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
       .addIssuance({
         assetAddress,
         tokenAddress,
-        assetAmount: 100,
-        tokenAmount: 1,
-        precision: 8,
+        assetSats: 100_0000_0000,
+        tokenSats: 1_0000_0000,
         blindedIssuance: true, // must be true, we'll blind the issuance!
         contract: {
           issuer_pubkey: '0000',
@@ -340,12 +336,11 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
         tokenPrevout: { txHash: issuanceTx.getHash(false), vout: 1 },
         prevoutBlinder: tokenBlinder,
         entropy,
-        assetAmount: 2000,
-        tokenAmount: 1,
+        assetSats: amountWithPrecisionToSatoshis(2000),
+        tokenSats: amountWithPrecisionToSatoshis(1),
         assetAddress,
         tokenAddress,
         witnessUtxo: tokenOutput,
-        precision: 8,
         blindedIssuance: true, // must be true, we'll blind the issuance!
       })
       .addOutput({
@@ -393,9 +388,8 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
     issuePsbt.addIssuance({
       assetAddress: address.fromOutputScript(assetPay.payment.output, regtest),
       tokenAddress: address.fromOutputScript(alice.payment.output, regtest),
-      assetAmount: 1,
-      tokenAmount: 2,
-      precision: 8,
+      assetSats: 1_0000_0000,
+      tokenSats: 2_0000_0000,
       // confidentialFlag: true,
     });
     issuePsbt.addOutputs([
@@ -443,7 +437,9 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
         {
           nonce,
           asset: tokenOutput.asset,
-          value: toConfidentialTokenAmount(2, 8),
+          value: confidential.satoshiToConfidentialValue(
+            amountWithPrecisionToSatoshis(2),
+          ),
           script: alice.payment.output,
         },
         {
@@ -519,12 +515,11 @@ describe('liquidjs-lib (issuances transactions with psbt)', () => {
         tokenPrevout: { txHash: confTx.getHash(false), vout: 0 },
         prevoutBlinder: tokenBlinder,
         entropy,
-        assetAmount: 200,
-        tokenAmount: 2,
+        assetSats: amountWithPrecisionToSatoshis(200),
+        tokenSats: amountWithPrecisionToSatoshis(2),
         assetAddress: aliceConfidential.payment.confidentialAddress,
         tokenAddress: aliceConfidential.payment.confidentialAddress,
         witnessUtxo: tokenOutput,
-        precision: 8,
         blindedIssuance: false,
       })
       .addOutput({

--- a/test/issuance.spec.ts
+++ b/test/issuance.spec.ts
@@ -107,9 +107,14 @@ describe('Issuance', () => {
     it('should create a valid Issuance object with an issuance contract', () => {
       const contract = fixtureWithContract.contract as issuance.IssuanceContract;
       const iss: issuance.Issuance = issuance.newIssuance(
-        fixtureWithContract.assetAmount,
-        fixtureWithContract.tokenAmount,
-        fixtureWithContract.precision,
+        issuance.amountWithPrecisionToSatoshis(
+          fixtureWithContract.assetAmount,
+          fixtureWithContract.precision,
+        ),
+        issuance.amountWithPrecisionToSatoshis(
+          fixtureWithContract.tokenAmount,
+          fixtureWithContract.precision,
+        ),
         contract,
       );
       assert.strictEqual(validate(iss), true);
@@ -122,13 +127,12 @@ describe('Issuance', () => {
 
   // a static set of arguments using with the function addIssuance.
   const issueArgs: AddIssuanceArgs = {
-    assetAmount: 100,
+    assetSats: issuance.amountWithPrecisionToSatoshis(100),
     assetAddress:
       'AzpudM1xn9jKRwnDFyDPDPTQ8jaxEUaSwe5JSFtVdULh6CwJftVVZcQWZbNacvYLLG24jTpKKNsNUVii',
-    tokenAmount: 1,
+    tokenSats: issuance.amountWithPrecisionToSatoshis(1),
     tokenAddress:
       'AzpudM1xn9jKRwnDFyDPDPTQ8jaxEUaSwe5JSFtVdULh6CwJftVVZcQWZbNacvYLLG24jTpKKNsNUVii',
-    precision: 8,
   };
 
   describe('Psbt: add issuance to input', () => {
@@ -226,19 +230,19 @@ describe('Issuance', () => {
 
     it('should throw an error if the token amount is < 0', () => {
       const psbt = createPsbt();
-      const argsInvalidToken = { ...issueArgs, tokenAmount: -2 };
+      const argsInvalidToken = { ...issueArgs, tokenSats: -2 };
       assert.throws(() => psbt.addIssuance(argsInvalidToken));
     });
 
     it('should throw an error if the asset amount is 0', () => {
       const psbt = createPsbt();
-      const argsInvalidAsset = { ...issueArgs, assetAmount: 0 };
+      const argsInvalidAsset = { ...issueArgs, assetSats: 0 };
       assert.throws(() => psbt.addIssuance(argsInvalidAsset));
     });
 
     it('should throw an error if the asset amount is < 0', () => {
       const psbt = createPsbt();
-      const argsInvalidAsset = { ...issueArgs, assetAmount: -12 };
+      const argsInvalidAsset = { ...issueArgs, assetSats: -12 };
       assert.throws(() => psbt.addIssuance(argsInvalidAsset));
     });
 
@@ -254,7 +258,7 @@ describe('Issuance', () => {
       assert.doesNotThrow(() => {
         psbt.addIssuance({
           ...issueArgs,
-          tokenAmount: 0,
+          tokenSats: 0,
           tokenAddress: undefined,
         });
       });
@@ -271,7 +275,7 @@ describe('Issuance', () => {
     it('should add one output if token amount = 0', () => {
       const psbt = createPsbt();
       const lenOutsBeforeIssuance = psbt.data.outputs.length;
-      psbt.addIssuance({ ...issueArgs, tokenAmount: 0 });
+      psbt.addIssuance({ ...issueArgs, tokenSats: 0 });
       const lenOutsAfterIssuance = psbt.data.outputs.length;
       assert.strictEqual(lenOutsAfterIssuance - lenOutsBeforeIssuance, 1);
     });

--- a/test/issuance.spec.ts
+++ b/test/issuance.spec.ts
@@ -234,9 +234,9 @@ describe('Issuance', () => {
       assert.throws(() => psbt.addIssuance(argsInvalidToken));
     });
 
-    it('should throw an error if the asset amount is 0', () => {
+    it('should throw an error if the asset amount is 0 & token amount is 0', () => {
       const psbt = createPsbt();
-      const argsInvalidAsset = { ...issueArgs, assetSats: 0 };
+      const argsInvalidAsset = { ...issueArgs, assetSats: 0, tokenSats: 0 };
       assert.throws(() => psbt.addIssuance(argsInvalidAsset));
     });
 

--- a/ts_src/issuance.ts
+++ b/ts_src/issuance.ts
@@ -79,35 +79,28 @@ export function hashContract(contract: IssuanceContract): Buffer {
 }
 
 /**
- * Returns an Issuance object for issuance transaction input.
- * @param assetAmount the number of asset to issue.
- * @param tokenAmount the number of token to issue.
- * @param precision the number of digit after the decimal point (8 for satoshi).
+ * Returns an unblinded Issuance object for issuance transaction input.
+ * @param assetSats the number of asset to issue.
+ * @param tokenSats the number of token to issue.
  * @param contract the asset ricarding contract of the issuance.
  */
 export function newIssuance(
-  assetAmount: number,
-  tokenAmount: number,
-  precision: number = 8,
+  assetSats: number,
+  tokenSats: number,
   contract?: IssuanceContract,
 ): Issuance {
-  if (assetAmount < 0) throw new Error('Invalid asset amount');
-  if (tokenAmount < 0) throw new Error('Invalid token amount');
-  if (precision < 0 || precision > 8) throw new Error('Invalid precision');
-  let contractHash = Buffer.alloc(32);
-  if (contract) {
-    if (contract.precision !== precision)
-      throw new Error('precision is not equal to the asset contract precision');
-    contractHash = hashContract(contract);
-  }
-  const iss: Issuance = {
-    assetAmount: toConfidentialAssetAmount(assetAmount, precision),
-    tokenAmount: toConfidentialTokenAmount(tokenAmount, precision),
+  if (assetSats <= 0) throw new Error('Invalid asset amount');
+  if (tokenSats < 0) throw new Error('Invalid token amount');
+
+  const contractHash = contract ? hashContract(contract) : Buffer.alloc(32);
+  const issuanceObject: Issuance = {
+    assetAmount: satoshiToConfidentialValue(assetSats),
+    tokenAmount: satoshiToConfidentialValue(tokenSats),
     assetBlindingNonce: Buffer.alloc(32),
     // in case of issuance, the asset entropy = the contract hash.
     assetEntropy: contractHash,
   };
-  return iss;
+  return issuanceObject;
 }
 
 export function isReissuance(issuance: Issuance): boolean {
@@ -184,27 +177,14 @@ function getTokenFlag(confidential: boolean): 1 | 0 {
 }
 
 /**
- * converts asset amount to confidential value.
+ * converts asset amount to satoshis.
+ * satoshis = assetAmount * 10^precision
  * @param assetAmount the asset amount.
- * @param precision the precision, 8 by default.
+ * @param precision the precision, 8 by default (like L-BTC).
  */
-export function toConfidentialAssetAmount(
+export function amountWithPrecisionToSatoshis(
   assetAmount: number,
   precision: number = 8,
-): Buffer {
-  const amount = Math.pow(10, precision) * assetAmount;
-  return satoshiToConfidentialValue(amount);
-}
-
-/**
- * converts token amount to confidential value.
- * @param assetAmount the token amount.
- * @param precision the precision, 8 by default.
- */
-export function toConfidentialTokenAmount(
-  tokenAmount: number,
-  precision: number = 8,
-): Buffer {
-  if (tokenAmount === 0) return Buffer.from('00', 'hex');
-  return toConfidentialAssetAmount(tokenAmount, precision);
+): number {
+  return Math.pow(10, precision) * assetAmount;
 }

--- a/ts_src/issuance.ts
+++ b/ts_src/issuance.ts
@@ -19,6 +19,7 @@ export interface IssuanceContract {
   precision: number;
   ticker: string;
   version: number;
+  [key: string]: any;
 }
 
 /**
@@ -65,15 +66,14 @@ export function hashContract(contract: IssuanceContract): Buffer {
   if (!validateIssuanceContract(contract))
     throw new Error('Invalid asset contract');
 
-  const constractJSON = `{"entity":{"domain":"${
-    contract.entity.domain
-  }"},"issuer_pubkey":"${contract.issuer_pubkey}","name":"${
-    contract.name
-  }","precision":${contract.precision},"ticker":"${
-    contract.ticker
-  }","version":${contract.version}}`;
+  const sortedKeys = Object.keys(contract).sort();
+  const sortedContract = sortedKeys.reduce(
+    (obj, key) => ({ ...obj, [key]: contract[key] }),
+    {},
+  );
+
   return bcrypto
-    .sha256(Buffer.from(constractJSON))
+    .sha256(Buffer.from(JSON.stringify(sortedContract)))
     .slice()
     .reverse();
 }

--- a/ts_src/issuance.ts
+++ b/ts_src/issuance.ts
@@ -89,13 +89,15 @@ export function newIssuance(
   tokenSats: number,
   contract?: IssuanceContract,
 ): Issuance {
-  if (assetSats <= 0) throw new Error('Invalid asset amount');
+  if (assetSats < 0) throw new Error('Invalid asset amount');
   if (tokenSats < 0) throw new Error('Invalid token amount');
 
   const contractHash = contract ? hashContract(contract) : Buffer.alloc(32);
   const issuanceObject: Issuance = {
-    assetAmount: satoshiToConfidentialValue(assetSats),
-    tokenAmount: satoshiToConfidentialValue(tokenSats),
+    assetAmount:
+      assetSats === 0 ? Buffer.of(0x00) : satoshiToConfidentialValue(assetSats),
+    tokenAmount:
+      tokenSats === 0 ? Buffer.of(0x00) : satoshiToConfidentialValue(tokenSats),
     assetBlindingNonce: Buffer.alloc(32),
     // in case of issuance, the asset entropy = the contract hash.
     assetEntropy: contractHash,

--- a/ts_src/types.ts
+++ b/ts_src/types.ts
@@ -63,7 +63,7 @@ export const Network = typeforce.compile({
 });
 
 export interface IssuanceBlindingKeys {
-  assetKey: Buffer;
+  assetKey?: Buffer;
   tokenKey?: Buffer;
 }
 


### PR DESCRIPTION
**non standard issuance contract field**

* contract fields are sorted alphabatically before serialization
* `IssuanceContract` takes any JSON-serializable additionnal field
* add a "contract with additionnal fields" fixture [from liquid](https://blockstream.info/liquid/asset/078826939104fd9a30aaf7cbd715055bcf799037adf0f008ed257240586a662c)

it closes #41 

**asset and token amounts are now expressed as satoshis in Add(Re)IssuanceArgs**

* drop the precision member in arguments (can be put in the contract anyway)
* rename `assetAmount` --> `assetSats`, same for `tokenAmount`
* keep an exported utility function `assetWithPrecisionToSatoshis` => (s = a * 10^p). 

it closes #38 

EDIT: it closes #45 

@asoltys @tiero please review