### PR TITLE
Allow to set `finalScriptWitness` in Psbt class

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,7 @@ import * as bip341 from './bip341';
 export * from './asset';
 export { address, crypto, networks, payments, script, confidential, issuance, bip341, };
 export { TaggedHashPrefix } from './crypto';
-export { Psbt, PsbtTxInput, PsbtTxOutput, Signer, SignerAsync, HDSigner, HDSignerAsync, } from './psbt';
+export { Psbt, PsbtTxInput, PsbtTxOutput, Signer, SignerAsync, HDSigner, HDSignerAsync, witnessStackToScriptWitness, } from './psbt';
 export { OPS as opcodes } from './ops';
 export { Transaction } from './transaction';
 export { Network as NetworkExtended } from './networks';

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ var __exportStar =
         __createBinding(exports, m, p);
   };
 Object.defineProperty(exports, '__esModule', { value: true });
-exports.Transaction = exports.opcodes = exports.Psbt = exports.bip341 = exports.issuance = exports.confidential = exports.script = exports.payments = exports.networks = exports.crypto = exports.address = void 0;
+exports.Transaction = exports.opcodes = exports.witnessStackToScriptWitness = exports.Psbt = exports.bip341 = exports.issuance = exports.confidential = exports.script = exports.payments = exports.networks = exports.crypto = exports.address = void 0;
 const address = __importStar(require('./address'));
 exports.address = address;
 const confidential = __importStar(require('./confidential'));
@@ -74,6 +74,12 @@ Object.defineProperty(exports, 'Psbt', {
   enumerable: true,
   get: function() {
     return psbt_1.Psbt;
+  },
+});
+Object.defineProperty(exports, 'witnessStackToScriptWitness', {
+  enumerable: true,
+  get: function() {
+    return psbt_1.witnessStackToScriptWitness;
   },
 });
 var ops_1 = require('./ops');

--- a/src/psbt.d.ts
+++ b/src/psbt.d.ts
@@ -205,6 +205,7 @@ isP2WSH: boolean) => {
     finalScriptSig: Buffer | undefined;
     finalScriptWitness: Buffer | undefined;
 };
+export declare function witnessStackToScriptWitness(witness: Buffer[]): Buffer;
 declare type AllScriptType = 'witnesspubkeyhash' | 'pubkeyhash' | 'multisig' | 'pubkey' | 'nonstandard' | 'p2sh-witnesspubkeyhash' | 'p2sh-pubkeyhash' | 'p2sh-multisig' | 'p2sh-pubkey' | 'p2sh-nonstandard' | 'p2wsh-pubkeyhash' | 'p2wsh-multisig' | 'p2wsh-pubkey' | 'p2wsh-nonstandard' | 'p2sh-p2wsh-pubkeyhash' | 'p2sh-p2wsh-multisig' | 'p2sh-p2wsh-pubkey' | 'p2sh-p2wsh-nonstandard';
 interface RngOpts {
     rng?(arg0: number): Buffer;

--- a/test/integration/taproot.spec.ts
+++ b/test/integration/taproot.spec.ts
@@ -189,6 +189,7 @@ describe('liquidjs-lib (transaction with taproot)', () => {
 
     const inputsStack = makeStackCheckSig(
       bob,
+      // @ts-ignore
       pset['__CACHE'].__TX,
       0,
       output,

--- a/test/integration/taproot.spec.ts
+++ b/test/integration/taproot.spec.ts
@@ -5,6 +5,7 @@ import {
   Transaction,
   payments,
   address,
+  Psbt,
 } from '../../ts_src/index';
 import { ECPair, ecc } from '../ecc';
 import { broadcast, faucet } from './_regtest';
@@ -21,6 +22,7 @@ import {
   BIP341Factory,
 } from '../../ts_src/bip341';
 import { compile, OPS } from '../../ts_src/script';
+import { witnessStackToScriptWitness } from '../../ts_src/psbt';
 
 const bip341 = BIP341Factory(ecc);
 
@@ -123,6 +125,91 @@ describe('liquidjs-lib (transaction with taproot)', () => {
 
     tx.ins[0].witness = [...inputsStack, ...taprootStack];
 
+    const hex = tx.toHex();
+    await broadcast(hex, true);
+  });
+
+  it('can create (and broadcast via 3PBP) a taproot scriptspend Pset (v0)', async () => {
+    const bobScript = compile([bob.publicKey.slice(1), OPS.OP_CHECKSIG]);
+
+    // in this exemple, alice is the internal key (can spend via keypath spend)
+    // however, the script tree allows bob to spend the coin with a simple p2pkh
+    const leaves: TaprootLeaf[] = [
+      {
+        scriptHex: bobScript.toString('hex'),
+      },
+      {
+        scriptHex:
+          '20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac',
+      },
+    ];
+
+    const hashTree = toHashTree(leaves);
+    const output = bip341.taprootOutputScript(alice.publicKey, hashTree);
+    const faucetAddress = address.fromOutputScript(output, net); // UNCONFIDENTIAL
+    const utxo = await faucet(faucetAddress);
+
+    const sendAmount = utxo.value - 10000;
+    // bob spends the coin with the script path of the leaf
+    // he gets the change and send the other one to the same taproot address
+
+    const pset = new Psbt({ network: net })
+      .addInput({
+        hash: utxo.txid,
+        index: utxo.vout,
+      })
+      .addOutput({
+        script: address.toOutputScript(faucetAddress, net),
+        asset: utxo.asset,
+        value: satoshiToConfidentialValue(sendAmount),
+        nonce: Buffer.of(0x00),
+      })
+      .addOutput({
+        script: address.toOutputScript(faucetAddress, net),
+        asset: utxo.asset,
+        value: satoshiToConfidentialValue(utxo.value - sendAmount - FEES),
+        nonce: Buffer.of(0x00),
+      })
+      .addOutput({
+        script: Buffer.alloc(0),
+        asset: utxo.asset,
+        value: satoshiToConfidentialValue(FEES),
+        nonce: Buffer.of(0x00),
+      });
+
+    const bobLeaf = leaves[0];
+    const leafHash = tapLeafHash(bobLeaf);
+    const pathToBobLeaf = findScriptPath(hashTree, leafHash);
+    const taprootStack = bip341.taprootSignScriptStack(
+      alice.publicKey,
+      bobLeaf,
+      hashTree.hash,
+      pathToBobLeaf,
+    );
+
+    const inputsStack = makeStackCheckSig(
+      bob,
+      pset['__CACHE'].__TX,
+      0,
+      output,
+      [
+        {
+          asset: AssetHash.fromHex(utxo.asset, false).bytes,
+          value: satoshiToConfidentialValue(utxo.value),
+        },
+      ],
+      leafHash,
+    );
+
+    pset.updateInput(0, {
+      finalScriptWitness: witnessStackToScriptWitness([
+        ...inputsStack,
+        ...taprootStack,
+      ]),
+    });
+
+    pset.finalizeAllInputs();
+    const tx = pset.extractTransaction();
     const hex = tx.toHex();
     await broadcast(hex, true);
   });

--- a/test/integration/taproot.spec.ts
+++ b/test/integration/taproot.spec.ts
@@ -189,8 +189,7 @@ describe('liquidjs-lib (transaction with taproot)', () => {
 
     const inputsStack = makeStackCheckSig(
       bob,
-      // @ts-ignore
-      pset['__CACHE'].__TX,
+      pset.TX,
       0,
       output,
       [

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -27,6 +27,7 @@ export {
   SignerAsync,
   HDSigner,
   HDSignerAsync,
+  witnessStackToScriptWitness,
 } from './psbt';
 export { OPS as opcodes } from './ops';
 export { Transaction } from './transaction';

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -164,6 +164,10 @@ export class Psbt {
   private __CACHE: PsbtCache;
   private opts: PsbtOpts;
 
+  get TX(): Transaction {
+    return this.__CACHE.__TX;
+  }
+
   constructor(
     opts: PsbtOptsOptional = {},
     readonly data: PsbtBase = new PsbtBase(new PsbtTransaction()),

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -520,26 +520,31 @@ export class Psbt {
       input,
       this.__CACHE,
     );
-    if (!script) throw new Error(`No script found for input #${inputIndex}`);
+    if (!script) {
+      // this is a trick to allow us to support segwitv1
+      // should be removed in the future
+      if (!input.finalScriptWitness)
+        throw new Error(`No script found for input #${inputIndex}`);
+    } else {
+      checkPartialSigSighashes(input);
+      const { finalScriptSig, finalScriptWitness } = finalScriptsFunc(
+        inputIndex,
+        input,
+        script,
+        isSegwit,
+        isP2SH,
+        isP2WSH,
+      );
 
-    checkPartialSigSighashes(input);
+      if (finalScriptSig) this.data.updateInput(inputIndex, { finalScriptSig });
+      if (finalScriptWitness)
+        this.data.updateInput(inputIndex, { finalScriptWitness });
+      if (!finalScriptSig && !finalScriptWitness)
+        throw new Error(`Unknown error finalizing input #${inputIndex}`);
 
-    const { finalScriptSig, finalScriptWitness } = finalScriptsFunc(
-      inputIndex,
-      input,
-      script,
-      isSegwit,
-      isP2SH,
-      isP2WSH,
-    );
+      this.data.clearFinalizedInput(inputIndex);
+    }
 
-    if (finalScriptSig) this.data.updateInput(inputIndex, { finalScriptSig });
-    if (finalScriptWitness)
-      this.data.updateInput(inputIndex, { finalScriptWitness });
-    if (!finalScriptSig && !finalScriptWitness)
-      throw new Error(`Unknown error finalizing input #${inputIndex}`);
-
-    this.data.clearFinalizedInput(inputIndex);
     return this;
   }
 
@@ -2207,7 +2212,7 @@ function sighashTypeToString(sighashType: number): string {
   return text;
 }
 
-function witnessStackToScriptWitness(witness: Buffer[]): Buffer {
+export function witnessStackToScriptWitness(witness: Buffer[]): Buffer {
   let buffer = Buffer.allocUnsafe(0);
 
   function writeSlice(slice: Buffer): void {


### PR DESCRIPTION
**This is a temporary solution, waiting for a full support of segwit v1 in `Psbt`. No breaking changes.**

- `finalizeInput` does not fail anymore **if and only if** the input has `finalScriptWitness` member defined and is a segwit v1 script.
- export `witnessStackToScriptWitness` util function (serialize the witness stack according to Psbt format)
- script path spend example in `taproot.specs.ts`

@tiero please review 