### PR TITLE
[BIP341] Include script hex in taproot hashTree

### DIFF
--- a/src/bip341.d.ts
+++ b/src/bip341.d.ts
@@ -28,7 +28,7 @@ export interface HashTree {
     right?: HashTree;
 }
 export declare function tapLeafHash(leaf: TaprootLeaf): Buffer;
-export declare function toHashTree(leaves: TaprootLeaf[]): HashTree;
+export declare function toHashTree(leaves: TaprootLeaf[], withScriptHex?: boolean): HashTree;
 /**
  * Given a MAST tree, it finds the path of a particular hash.
  * @param node - the root of the tree

--- a/src/bip341.js
+++ b/src/bip341.js
@@ -43,8 +43,8 @@ function toHashTree(leaves, withScriptHex = false) {
     default:
       // 2 or more entries
       const middleIndex = Math.ceil(leaves.length / 2);
-      const left = toHashTree(leaves.slice(0, middleIndex));
-      const right = toHashTree(leaves.slice(middleIndex));
+      const left = toHashTree(leaves.slice(0, middleIndex), withScriptHex);
+      const right = toHashTree(leaves.slice(middleIndex), withScriptHex);
       let leftHash = left.hash;
       let rightHash = right.hash;
       // check if left is greater than right

--- a/src/bip341.js
+++ b/src/bip341.js
@@ -26,7 +26,7 @@ function tapLeafHash(leaf) {
 }
 exports.tapLeafHash = tapLeafHash;
 // recursively build the Taproot tree from a ScriptTree structure
-function toHashTree(leaves) {
+function toHashTree(leaves, withScriptHex = false) {
   switch (leaves.length) {
     case 0:
       return { hash: Buffer.alloc(32) };
@@ -38,6 +38,7 @@ function toHashTree(leaves) {
       }
       return {
         hash: tapLeafHash(leaf),
+        scriptHex: withScriptHex ? leaf.scriptHex : undefined,
       };
     default:
       // 2 or more entries

--- a/ts_src/bip341.ts
+++ b/ts_src/bip341.ts
@@ -74,7 +74,7 @@ export function tapLeafHash(leaf: TaprootLeaf): Buffer {
 }
 
 // recursively build the Taproot tree from a ScriptTree structure
-export function toHashTree(leaves: TaprootLeaf[]): HashTree {
+export function toHashTree(leaves: TaprootLeaf[], withScriptHex = false): HashTree {
   switch (leaves.length) {
     case 0:
       return { hash: Buffer.alloc(32) };
@@ -87,6 +87,7 @@ export function toHashTree(leaves: TaprootLeaf[]): HashTree {
 
       return {
         hash: tapLeafHash(leaf),
+        scriptHex: withScriptHex ? leaf.scriptHex : undefined,
       };
     default:
       // 2 or more entries

--- a/ts_src/bip341.ts
+++ b/ts_src/bip341.ts
@@ -74,7 +74,10 @@ export function tapLeafHash(leaf: TaprootLeaf): Buffer {
 }
 
 // recursively build the Taproot tree from a ScriptTree structure
-export function toHashTree(leaves: TaprootLeaf[], withScriptHex = false): HashTree {
+export function toHashTree(
+  leaves: TaprootLeaf[],
+  withScriptHex = false,
+): HashTree {
   switch (leaves.length) {
     case 0:
       return { hash: Buffer.alloc(32) };

--- a/ts_src/bip341.ts
+++ b/ts_src/bip341.ts
@@ -95,8 +95,8 @@ export function toHashTree(
     default:
       // 2 or more entries
       const middleIndex = Math.ceil(leaves.length / 2);
-      const left = toHashTree(leaves.slice(0, middleIndex));
-      const right = toHashTree(leaves.slice(middleIndex));
+      const left = toHashTree(leaves.slice(0, middleIndex), withScriptHex);
+      const right = toHashTree(leaves.slice(middleIndex), withScriptHex);
       let leftHash = left.hash;
       let rightHash = right.hash;
 


### PR DESCRIPTION
add an optional parameter in `toHashTree` function. It aims to "export" the raw script hex of taproot leaves in the HashTree structure -> scriptHex was already a member of HashTree but never set up by the function.

_no breaking changes_

@tiero please review