### PR TITLE
move signature check in default finalizer only

### DIFF
--- a/ts_src/psetv2/finalizer.ts
+++ b/ts_src/psetv2/finalizer.ts
@@ -121,7 +121,9 @@ const defaultFinalizer: FinalizeFunc = (inIndex: number, pset: Pset) => {
     (!input.tapKeySig || input.tapKeySig.length === 0) &&
     (!input.tapScriptSig || input.tapScriptSig.length === 0)
   ) {
-    throw new Error(`Missing partial signatures for input at index ${inIndex}. If the script does not have a CHECKSIG operation you must pass a custom finalizer function`);
+    throw new Error(
+      `Missing partial signatures for input at index ${inIndex}. If the script does not have a CHECKSIG operation you must pass a custom finalizer function`,
+    );
   }
 
   if (input.isTaproot()) return finalizeTaprootInput(inIndex, pset);

--- a/ts_src/psetv2/finalizer.ts
+++ b/ts_src/psetv2/finalizer.ts
@@ -121,7 +121,7 @@ const defaultFinalizer: FinalizeFunc = (inIndex: number, pset: Pset) => {
     (!input.tapKeySig || input.tapKeySig.length === 0) &&
     (!input.tapScriptSig || input.tapScriptSig.length === 0)
   ) {
-    throw new Error('Missing input partial signatures');
+    throw new Error(`Missing partial signatures for input at index ${inIndex}. If the script does not have a CHECKSIG operation you must pass a custom finalizer function`);
   }
 
   if (input.isTaproot()) return finalizeTaprootInput(inIndex, pset);

--- a/ts_src/psetv2/finalizer.ts
+++ b/ts_src/psetv2/finalizer.ts
@@ -54,13 +54,6 @@ export class Finalizer {
     if (!input.getUtxo()) {
       throw new Error('Missing input (non-)witness utxo');
     }
-    if (
-      (!input.partialSigs || input.partialSigs!.length === 0) &&
-      (!input.tapKeySig || input.tapKeySig.length === 0) &&
-      (!input.tapScriptSig || input.tapScriptSig.length === 0)
-    ) {
-      throw new Error('Missing input partial signatures');
-    }
 
     const pset = this.pset.copy();
 
@@ -121,6 +114,16 @@ function getScriptFromInput(input: PsetInput): GetScriptReturn {
 
 const defaultFinalizer: FinalizeFunc = (inIndex: number, pset: Pset) => {
   const input = pset.inputs[inIndex];
+
+  // if we use the defaut finalizer we assume the input script has a CHECKSIG operation
+  if (
+    (!input.partialSigs || input.partialSigs!.length === 0) &&
+    (!input.tapKeySig || input.tapKeySig.length === 0) &&
+    (!input.tapScriptSig || input.tapScriptSig.length === 0)
+  ) {
+    throw new Error('Missing input partial signatures');
+  }
+
   if (input.isTaproot()) return finalizeTaprootInput(inIndex, pset);
   return finalizeInput(inIndex, pset);
 };


### PR DESCRIPTION
the assumption that all locking scripts have a CHECKSIG operation is wrong, therefore I moved the check on the signatures fields being empty in the default finalizer only, leaving possibility the code to execute if a custom finalizer is passed 

Please review @altafan @louisinger 