### PR TITLE
Support SIGHASH_DEFAULT and update locktime on inputs

### DIFF
--- a/src/psetv2/creator.js
+++ b/src/psetv2/creator.js
@@ -83,10 +83,11 @@ class CreatorOutput {
 exports.CreatorOutput = CreatorOutput;
 class Creator {
   static newPset(args) {
+    const locktime = args ? args.locktime : undefined;
     const txModifiable = new bitset_1.default(0);
     txModifiable.set(0);
     txModifiable.set(1);
-    const globals = new globals_1.PsetGlobal(2, 0, 0, 2);
+    const globals = new globals_1.PsetGlobal(2, 0, 0, 2, locktime);
     globals.txModifiable = txModifiable;
     globals.xpubs = [];
     globals.scalars = [];

--- a/src/psetv2/finalizer.js
+++ b/src/psetv2/finalizer.js
@@ -28,7 +28,7 @@ class Finalizer {
     if (input.isFinalized()) {
       return this;
     }
-    if (input.sighashType <= 0) {
+    if (input.sighashType === undefined) {
       throw new Error('Missing input sighash type');
     }
     if (!input.getUtxo()) {

--- a/src/psetv2/input.js
+++ b/src/psetv2/input.js
@@ -113,7 +113,7 @@ class PsetInput {
           input.partialSigs.push({ pubkey: pk, signature });
           break;
         case fields_1.InputTypes.SIGHASH_TYPE:
-          if (input.sighashType > 0) {
+          if (input.sighashType !== undefined) {
             throw new InputDuplicateFieldError('sighash type');
           }
           if (kp.value.length !== 4) {
@@ -612,6 +612,9 @@ class PsetInput {
         'Missing input issuance inflation keys commitment or blind proof',
       );
     }
+    if (this.sighashType !== undefined && this.sighashType < 0) {
+      throw new Error('Invalid sighash type');
+    }
     return this;
   }
   hasIssuance() {
@@ -713,7 +716,7 @@ class PsetInput {
         keyPairs.push(new key_pair_1.KeyPair(key, signature));
       });
     }
-    if (this.sighashType > 0) {
+    if (this.sighashType !== undefined) {
       const key = new key_pair_1.Key(fields_1.InputTypes.SIGHASH_TYPE);
       const value = Buffer.allocUnsafe(4);
       value.writeUInt32LE(this.sighashType);

--- a/src/psetv2/updater.d.ts
+++ b/src/psetv2/updater.d.ts
@@ -57,6 +57,8 @@ export declare class Updater {
     addInIssuance(inIndex: number, args: IssuanceOpts): this;
     addInReissuance(inIndex: number, args: ReissuanceOpts): this;
     addInPartialSignature(inIndex: number, ps: PartialSig, validator: ValidateSigFunction): this;
+    addInTimeLocktime(inIndex: number, locktime: number): this;
+    addInHeightLocktime(inIndex: number, locktime: number): this;
     addInTapKeySig(inIndex: number, sig: Buffer, genesisBlockHash: Buffer, validator: ValidateSigFunction): this;
     addInTapScriptSig(inIndex: number, sig: TapScriptSig, genesisBlockHash: Buffer, validator: ValidateSigFunction): this;
     addInTapLeafScript(inIndex: number, tapLeafScript: TapLeafScript): this;

--- a/src/psetv2/updater.js
+++ b/src/psetv2/updater.js
@@ -81,7 +81,7 @@ class Updater {
         if (previousOutput.rangeProof)
           this.addInUtxoRangeProof(inputIndex, previousOutput.rangeProof);
       }
-      if (input.sighashType)
+      if (input.sighashType !== undefined)
         this.addInSighashType(inputIndex, input.sighashType);
       if (input.tapInternalKey)
         this.addInTapInternalKey(inputIndex, input.tapInternalKey);
@@ -200,7 +200,7 @@ class Updater {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
       throw new Error('Input index out of range');
     }
-    if (sighashType <= 0) {
+    if (sighashType < 0) {
       throw new Error('Invalid sighash type');
     }
     const pset = this.pset.copy();

--- a/src/psetv2/updater.js
+++ b/src/psetv2/updater.js
@@ -121,12 +121,12 @@ class Updater {
   }
   addInNonWitnessUtxo(inIndex, nonWitnessUtxo) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     const txid = nonWitnessUtxo.getHash(false);
     if (!txid.equals(pset.inputs[inIndex].previousTxid)) {
-      throw new Error('non-witness utxo hash does not match prevout txid');
+      throw new Error('Non-witness utxo hash does not match prevout txid');
     }
     pset.inputs[inIndex].nonWitnessUtxo = nonWitnessUtxo;
     pset.sanityCheck();
@@ -137,7 +137,7 @@ class Updater {
   }
   addInWitnessUtxo(inIndex, witnessUtxo) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].witnessUtxo = witnessUtxo;
@@ -149,7 +149,7 @@ class Updater {
   }
   addInRedeemScript(inIndex, redeemScript) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].redeemScript = redeemScript;
@@ -161,7 +161,7 @@ class Updater {
   }
   addInWitnessScript(inIndex, witnessScript) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].witnessScript = witnessScript;
@@ -173,10 +173,10 @@ class Updater {
   }
   addInBIP32Derivation(inIndex, d) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     if (d.pubkey.length !== 33) {
-      throw new Error('invalid pubkey length');
+      throw new Error('Invalid pubkey length');
     }
     const pset = this.pset.copy();
     if (!pset.inputs[inIndex].bip32Derivation) {
@@ -187,7 +187,7 @@ class Updater {
         pubkey.equals(d.pubkey),
       )
     ) {
-      throw new Error('duplicated bip32 derivation pubkey');
+      throw new Error('Duplicated bip32 derivation pubkey');
     }
     pset.inputs[inIndex].bip32Derivation.push(d);
     pset.sanityCheck();
@@ -198,10 +198,10 @@ class Updater {
   }
   addInSighashType(inIndex, sighashType) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     if (sighashType <= 0) {
-      throw new Error('invalid sighash type');
+      throw new Error('Invalid sighash type');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].sighashType = sighashType;
@@ -213,7 +213,7 @@ class Updater {
   }
   addInUtxoRangeProof(inIndex, proof) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].utxoRangeProof = proof;
@@ -360,7 +360,7 @@ class Updater {
         pubkey.equals(ps.pubkey),
       )
     ) {
-      throw new Error('duplicated signature pubkey');
+      throw new Error('Duplicated signature pubkey');
     }
     const pset = this.pset.copy();
     // validate signature against input's preimage and pubkey
@@ -368,12 +368,42 @@ class Updater {
     const preimage = pset.getInputPreimage(inIndex, sighashType);
     const { signature } = bscript.signature.decode(ps.signature);
     if (!validator(ps.pubkey, preimage, signature)) {
-      throw new Error('invalid signature');
+      throw new Error('Invalid signature');
     }
     if (!pset.inputs[inIndex].partialSigs) {
       pset.inputs[inIndex].partialSigs = [];
     }
     pset.inputs[inIndex].partialSigs.push(ps);
+    pset.sanityCheck();
+    this.pset.globals = pset.globals;
+    this.pset.inputs = pset.inputs;
+    this.pset.outputs = pset.outputs;
+    return this;
+  }
+  addInTimeLocktime(inIndex, locktime) {
+    if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
+      throw new Error('Input index out of range');
+    }
+    if (locktime < 0) {
+      throw new Error('Invalid required time locktime');
+    }
+    const pset = this.pset.copy();
+    pset.inputs[inIndex].requiredTimeLocktime = locktime;
+    pset.sanityCheck();
+    this.pset.globals = pset.globals;
+    this.pset.inputs = pset.inputs;
+    this.pset.outputs = pset.outputs;
+    return this;
+  }
+  addInHeightLocktime(inIndex, locktime) {
+    if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
+      throw new Error('Input index out of range');
+    }
+    if (locktime < 0) {
+      throw new Error('Invalid required height locktime');
+    }
+    const pset = this.pset.copy();
+    pset.inputs[inIndex].requiredHeightLocktime = locktime;
     pset.sanityCheck();
     this.pset.globals = pset.globals;
     this.pset.inputs = pset.inputs;
@@ -456,7 +486,7 @@ class Updater {
   }
   addInTapLeafScript(inIndex, tapLeafScript) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     if (!pset.inputs[inIndex].tapLeafScript) {
@@ -471,10 +501,10 @@ class Updater {
   }
   addInTapBIP32Derivation(inIndex, d) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     if (d.pubkey.length !== 33) {
-      throw new Error('invalid input taproot pubkey length');
+      throw new Error('Invalid input taproot pubkey length');
     }
     const pset = this.pset.copy();
     if (!pset.inputs[inIndex].tapBip32Derivation) {
@@ -485,7 +515,7 @@ class Updater {
         pubkey.equals(d.pubkey),
       )
     ) {
-      throw new Error('duplicated taproot bip32 derivation pubkey');
+      throw new Error('Duplicated taproot bip32 derivation pubkey');
     }
     pset.inputs[inIndex].tapBip32Derivation.push(d);
     pset.sanityCheck();
@@ -496,16 +526,16 @@ class Updater {
   }
   addInTapInternalKey(inIndex, tapInternalKey) {
     if (inIndex < 0 || inIndex > this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     if (tapInternalKey.length !== 32) {
-      throw new Error('invalid taproot internal key length');
+      throw new Error('Invalid taproot internal key length');
     }
     if (
       this.pset.inputs[inIndex].tapInternalKey &&
       this.pset.inputs[inIndex].tapInternalKey.length > 0
     ) {
-      throw new Error('duplicated taproot internal key');
+      throw new Error('Duplicated taproot internal key');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].tapInternalKey = tapInternalKey;
@@ -517,16 +547,16 @@ class Updater {
   }
   addInTapMerkleRoot(inIndex, tapMerkleRoot) {
     if (inIndex < 0 || inIndex > this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     if (tapMerkleRoot.length !== 32) {
-      throw new Error('invalid taproot merkle root length');
+      throw new Error('Invalid taproot merkle root length');
     }
     if (
       this.pset.inputs[inIndex].tapMerkleRoot &&
       this.pset.inputs[inIndex].tapMerkleRoot.length > 0
     ) {
-      throw new Error('duplicated taproot merkle root');
+      throw new Error('Duplicated taproot merkle root');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].tapMerkleRoot = tapMerkleRoot;
@@ -538,10 +568,10 @@ class Updater {
   }
   addOutBIP32Derivation(outIndex, d) {
     if (outIndex < 0 || outIndex >= this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     if (d.pubkey.length !== 33) {
-      throw new Error('invalid pubkey length');
+      throw new Error('Invalid pubkey length');
     }
     const pset = this.pset.copy();
     if (!pset.outputs[outIndex].bip32Derivation) {
@@ -552,7 +582,7 @@ class Updater {
         pubkey.equals(d.pubkey),
       )
     ) {
-      throw new Error('duplicated bip32 derivation pubkey');
+      throw new Error('Duplicated bip32 derivation pubkey');
     }
     pset.outputs[outIndex].bip32Derivation.push(d);
     pset.sanityCheck();
@@ -563,7 +593,7 @@ class Updater {
   }
   addOutRedeemScript(outIndex, redeemScript) {
     if (outIndex < 0 || outIndex >= this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     const pset = this.pset.copy();
     pset.outputs[outIndex].redeemScript = redeemScript;
@@ -575,7 +605,7 @@ class Updater {
   }
   addOutWitnessScript(outIndex, witnessScript) {
     if (outIndex < 0 || outIndex >= this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     const pset = this.pset.copy();
     pset.outputs[outIndex].witnessScript = witnessScript;
@@ -587,16 +617,16 @@ class Updater {
   }
   addOutTapInternalKey(outIndex, tapInternalKey) {
     if (outIndex < 0 || outIndex > this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     if (tapInternalKey.length !== 32) {
-      throw new Error('invalid taproot internal key length');
+      throw new Error('Invalid taproot internal key length');
     }
     if (
       this.pset.outputs[outIndex].tapInternalKey &&
       this.pset.outputs[outIndex].tapInternalKey.length > 0
     ) {
-      throw new Error('duplicated taproot internal key');
+      throw new Error('Duplicated taproot internal key');
     }
     const pset = this.pset.copy();
     pset.outputs[outIndex].tapInternalKey = tapInternalKey;
@@ -608,10 +638,10 @@ class Updater {
   }
   addOutTapTree(outIndex, tapTree) {
     if (outIndex < 0 || outIndex > this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     if (this.pset.outputs[outIndex].tapTree) {
-      throw new Error('duplicated taproot tree');
+      throw new Error('Duplicated taproot tree');
     }
     const pset = this.pset.copy();
     pset.outputs[outIndex].tapTree = tapTree;
@@ -623,10 +653,10 @@ class Updater {
   }
   addOutTapBIP32Derivation(outIndex, d) {
     if (outIndex < 0 || outIndex >= this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     if (d.pubkey.length !== 33) {
-      throw new Error('invalid output taproot pubkey length');
+      throw new Error('Invalid output taproot pubkey length');
     }
     const pset = this.pset.copy();
     if (!pset.outputs[outIndex].tapBip32Derivation) {
@@ -637,7 +667,7 @@ class Updater {
         pubkey.equals(d.pubkey),
       )
     ) {
-      throw new Error('duplicated taproot bip32 derivation pubkey');
+      throw new Error('Duplicated taproot bip32 derivation pubkey');
     }
     pset.outputs[outIndex].tapBip32Derivation.push(d);
     pset.sanityCheck();
@@ -648,27 +678,27 @@ class Updater {
   }
   validateIssuanceInput(inIndex) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const input = this.pset.inputs[inIndex];
     if (input.issuanceAssetEntropy && input.issuanceAssetEntropy.length > 0) {
-      throw new Error('input ' + inIndex + ' already has an issuance');
+      throw new Error('Input ' + inIndex + ' already has an issuance');
     }
   }
   validateReissuanceInput(inIndex) {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const input = this.pset.inputs[inIndex];
     if (input.issuanceAssetEntropy && input.issuanceAssetEntropy.length > 0) {
-      throw new Error('input ' + inIndex + ' already has an issuance');
+      throw new Error(`Input ${inIndex} already has an issuance`);
     }
     const prevout = input.getUtxo();
     if (!prevout) {
-      throw new Error('input is missing prevout (non-)witness utxo');
+      throw new Error('Input is missing prevout (non-)witness utxo');
     }
     if (prevout.nonce.length <= 1) {
-      throw new Error('input prevout (non-)witness utxo must be confidential');
+      throw new Error('Input prevout (non-)witness utxo must be confidential');
     }
   }
 }
@@ -677,25 +707,25 @@ function validateAddInIssuanceArgs(args) {
   const assetAmount = args.assetAmount || 0;
   const tokenAmount = args.tokenAmount || 0;
   if (assetAmount <= 0 && tokenAmount <= 0) {
-    throw new Error('either asset or token amounts must be a positive number');
+    throw new Error('Either asset or token amounts must be a positive number');
   }
   if (assetAmount > 0) {
     if (!args.assetAddress || args.assetAddress.length === 0) {
       throw new Error(
-        'asset address must be defined if asset amount is non-zero',
+        'Asset address must be defined if asset amount is non-zero',
       );
     }
   }
   if (tokenAmount > 0) {
     if (!args.tokenAddress || args.tokenAddress.length === 0) {
       throw new Error(
-        'token address must be defined if token amount is non-zero',
+        'Token address must be defined if token amount is non-zero',
       );
     }
   }
   if (!matchAddressesType(args.assetAddress, args.tokenAddress)) {
     throw new Error(
-      'asset and token addresses must be of same network and both unconfidential or confidential',
+      'Asset and token addresses must be of same network and both unconfidential or confidential',
     );
   }
 }
@@ -705,34 +735,34 @@ function validateAddInReissuanceArgs(args) {
       ? Buffer.from(args.entropy, 'hex').reverse()
       : args.entropy;
   if (entropy.length !== 32) {
-    throw new Error('invalid entropy length');
+    throw new Error('Invalid entropy length');
   }
   const blinder =
     typeof args.tokenAssetBlinder === 'string'
       ? Buffer.from(args.tokenAssetBlinder, 'hex').reverse()
       : args.tokenAssetBlinder;
   if (blinder.length !== 32) {
-    throw new Error('invalid token asset blinder length');
+    throw new Error('Invalid token asset blinder length');
   }
   if (args.assetAmount <= 0) {
-    throw new Error('asset amount must be a positive number');
+    throw new Error('Asset amount must be a positive number');
   }
   if (args.tokenAmount <= 0) {
-    throw new Error('token amount must be a positive number');
+    throw new Error('Token amount must be a positive number');
   }
   if (args.assetAddress.length === 0) {
-    throw new Error('missing asset address');
+    throw new Error('Missing asset address');
   }
   if (args.tokenAddress.length === 0) {
-    throw new Error('missing token address');
+    throw new Error('Missing token address');
   }
   if (!matchAddressesType(args.assetAddress, args.tokenAddress)) {
     throw new Error(
-      'asset and token addresses must be both of same network and both confidential',
+      'Asset and token addresses must be both of same network and both confidential',
     );
   }
   if (!(0, address_1.isConfidential)(args.assetAddress)) {
-    throw new Error('asset and token addresses must be both confidential');
+    throw new Error('Asset and token addresses must be both confidential');
   }
 }
 function matchAddressesType(addrA, addrB) {
@@ -753,7 +783,7 @@ function matchAddressesType(addrA, addrB) {
 }
 function validatePartialSignature(psig) {
   if (psig.pubkey.length !== 33) {
-    throw new Error('invalid pubkey length');
+    throw new Error('Invalid pubkey length');
   }
   bscript.signature.decode(psig.signature);
 }

--- a/ts_src/psetv2/creator.ts
+++ b/ts_src/psetv2/creator.ts
@@ -106,11 +106,12 @@ export class Creator {
     outputs?: CreatorOutput[];
     locktime?: number;
   }): Pset {
+    const locktime = args ? args.locktime : undefined;
     const txModifiable = new BitSet(0);
     txModifiable.set(0);
     txModifiable.set(1);
 
-    const globals = new PsetGlobal(2, 0, 0, 2);
+    const globals = new PsetGlobal(2, 0, 0, 2, locktime);
     globals.txModifiable = txModifiable;
     globals.xpubs = [];
     globals.scalars = [];

--- a/ts_src/psetv2/finalizer.ts
+++ b/ts_src/psetv2/finalizer.ts
@@ -48,7 +48,7 @@ export class Finalizer {
     if (input.isFinalized()) {
       return this;
     }
-    if (input.sighashType! <= 0) {
+    if (input.sighashType === undefined) {
       throw new Error('Missing input sighash type');
     }
     if (!input.getUtxo()) {

--- a/ts_src/psetv2/input.ts
+++ b/ts_src/psetv2/input.ts
@@ -83,7 +83,7 @@ export class PsetInput {
           input.partialSigs!.push({ pubkey: pk, signature });
           break;
         case InputTypes.SIGHASH_TYPE:
-          if (input.sighashType! > 0) {
+          if (input.sighashType !== undefined) {
             throw new InputDuplicateFieldError('sighash type');
           }
           if (kp.value.length !== 4) {
@@ -632,6 +632,10 @@ export class PsetInput {
       );
     }
 
+    if (this.sighashType !== undefined && this.sighashType < 0) {
+      throw new Error('Invalid sighash type');
+    }
+
     return this;
   }
 
@@ -752,7 +756,7 @@ export class PsetInput {
       });
     }
 
-    if (this.sighashType! > 0) {
+    if (this.sighashType !== undefined) {
       const key = new Key(InputTypes.SIGHASH_TYPE);
       const value = Buffer.allocUnsafe(4);
       value.writeUInt32LE(this.sighashType!);

--- a/ts_src/psetv2/updater.ts
+++ b/ts_src/psetv2/updater.ts
@@ -111,7 +111,7 @@ export class Updater {
           this.addInUtxoRangeProof(inputIndex, previousOutput.rangeProof);
       }
 
-      if (input.sighashType)
+      if (input.sighashType !== undefined)
         this.addInSighashType(inputIndex, input.sighashType);
 
       if (input.tapInternalKey)
@@ -261,7 +261,7 @@ export class Updater {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
       throw new Error('Input index out of range');
     }
-    if (sighashType <= 0) {
+    if (sighashType < 0) {
       throw new Error('Invalid sighash type');
     }
 

--- a/ts_src/psetv2/updater.ts
+++ b/ts_src/psetv2/updater.ts
@@ -165,12 +165,12 @@ export class Updater {
 
   addInNonWitnessUtxo(inIndex: number, nonWitnessUtxo: Transaction): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     const txid = nonWitnessUtxo.getHash(false);
     if (!txid.equals(pset.inputs[inIndex].previousTxid)) {
-      throw new Error('non-witness utxo hash does not match prevout txid');
+      throw new Error('Non-witness utxo hash does not match prevout txid');
     }
     pset.inputs[inIndex].nonWitnessUtxo = nonWitnessUtxo;
     pset.sanityCheck();
@@ -184,7 +184,7 @@ export class Updater {
 
   addInWitnessUtxo(inIndex: number, witnessUtxo: TxOutput): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].witnessUtxo = witnessUtxo;
@@ -199,7 +199,7 @@ export class Updater {
 
   addInRedeemScript(inIndex: number, redeemScript: Buffer): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].redeemScript = redeemScript;
@@ -214,7 +214,7 @@ export class Updater {
 
   addInWitnessScript(inIndex: number, witnessScript: Buffer): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     const pset = this.pset.copy();
     pset.inputs[inIndex].witnessScript = witnessScript;
@@ -229,11 +229,11 @@ export class Updater {
 
   addInBIP32Derivation(inIndex: number, d: Bip32Derivation): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
 
     if (d.pubkey.length !== 33) {
-      throw new Error('invalid pubkey length');
+      throw new Error('Invalid pubkey length');
     }
 
     const pset = this.pset.copy();
@@ -245,7 +245,7 @@ export class Updater {
         pubkey.equals(d.pubkey),
       )
     ) {
-      throw new Error('duplicated bip32 derivation pubkey');
+      throw new Error('Duplicated bip32 derivation pubkey');
     }
     pset.inputs[inIndex].bip32Derivation!.push(d);
     pset.sanityCheck();
@@ -259,10 +259,10 @@ export class Updater {
 
   addInSighashType(inIndex: number, sighashType: number): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     if (sighashType <= 0) {
-      throw new Error('invalid sighash type');
+      throw new Error('Invalid sighash type');
     }
 
     const pset = this.pset.copy();
@@ -278,7 +278,7 @@ export class Updater {
 
   addInUtxoRangeProof(inIndex: number, proof: Buffer): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
 
     const pset = this.pset.copy();
@@ -439,7 +439,7 @@ export class Updater {
         pubkey.equals(ps.pubkey),
       )
     ) {
-      throw new Error('duplicated signature pubkey');
+      throw new Error('Duplicated signature pubkey');
     }
 
     const pset = this.pset.copy();
@@ -449,7 +449,7 @@ export class Updater {
     const preimage = pset.getInputPreimage(inIndex, sighashType);
     const { signature } = bscript.signature.decode(ps.signature);
     if (!validator(ps.pubkey, preimage, signature)) {
-      throw new Error('invalid signature');
+      throw new Error('Invalid signature');
     }
 
     if (!pset.inputs[inIndex].partialSigs) {
@@ -457,6 +457,42 @@ export class Updater {
     }
     pset.inputs[inIndex].partialSigs!.push(ps);
 
+    pset.sanityCheck();
+
+    this.pset.globals = pset.globals;
+    this.pset.inputs = pset.inputs;
+    this.pset.outputs = pset.outputs;
+
+    return this;
+  }
+
+  addInTimeLocktime(inIndex: number, locktime: number): this {
+    if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
+      throw new Error('Input index out of range');
+    }
+    if (locktime < 0) {
+      throw new Error('Invalid required time locktime');
+    }
+    const pset = this.pset.copy();
+    pset.inputs[inIndex].requiredTimeLocktime = locktime;
+    pset.sanityCheck();
+
+    this.pset.globals = pset.globals;
+    this.pset.inputs = pset.inputs;
+    this.pset.outputs = pset.outputs;
+
+    return this;
+  }
+
+  addInHeightLocktime(inIndex: number, locktime: number): this {
+    if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
+      throw new Error('Input index out of range');
+    }
+    if (locktime < 0) {
+      throw new Error('Invalid required height locktime');
+    }
+    const pset = this.pset.copy();
+    pset.inputs[inIndex].requiredHeightLocktime = locktime;
     pset.sanityCheck();
 
     this.pset.globals = pset.globals;
@@ -567,7 +603,7 @@ export class Updater {
 
   addInTapLeafScript(inIndex: number, tapLeafScript: TapLeafScript): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
 
     const pset = this.pset.copy();
@@ -586,11 +622,11 @@ export class Updater {
 
   addInTapBIP32Derivation(inIndex: number, d: TapBip32Derivation): this {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
 
     if (d.pubkey.length !== 33) {
-      throw new Error('invalid input taproot pubkey length');
+      throw new Error('Invalid input taproot pubkey length');
     }
 
     const pset = this.pset.copy();
@@ -602,7 +638,7 @@ export class Updater {
         pubkey.equals(d.pubkey),
       )
     ) {
-      throw new Error('duplicated taproot bip32 derivation pubkey');
+      throw new Error('Duplicated taproot bip32 derivation pubkey');
     }
     pset.inputs[inIndex].tapBip32Derivation!.push(d);
     pset.sanityCheck();
@@ -616,16 +652,16 @@ export class Updater {
 
   addInTapInternalKey(inIndex: number, tapInternalKey: TapInternalKey): this {
     if (inIndex < 0 || inIndex > this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     if (tapInternalKey.length !== 32) {
-      throw new Error('invalid taproot internal key length');
+      throw new Error('Invalid taproot internal key length');
     }
     if (
       this.pset.inputs[inIndex].tapInternalKey &&
       this.pset.inputs[inIndex].tapInternalKey!.length > 0
     ) {
-      throw new Error('duplicated taproot internal key');
+      throw new Error('Duplicated taproot internal key');
     }
 
     const pset = this.pset.copy();
@@ -641,16 +677,16 @@ export class Updater {
 
   addInTapMerkleRoot(inIndex: number, tapMerkleRoot: TapMerkleRoot): this {
     if (inIndex < 0 || inIndex > this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
     if (tapMerkleRoot.length !== 32) {
-      throw new Error('invalid taproot merkle root length');
+      throw new Error('Invalid taproot merkle root length');
     }
     if (
       this.pset.inputs[inIndex].tapMerkleRoot &&
       this.pset.inputs[inIndex].tapMerkleRoot!.length > 0
     ) {
-      throw new Error('duplicated taproot merkle root');
+      throw new Error('Duplicated taproot merkle root');
     }
 
     const pset = this.pset.copy();
@@ -666,11 +702,11 @@ export class Updater {
 
   addOutBIP32Derivation(outIndex: number, d: Bip32Derivation): this {
     if (outIndex < 0 || outIndex >= this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
 
     if (d.pubkey.length !== 33) {
-      throw new Error('invalid pubkey length');
+      throw new Error('Invalid pubkey length');
     }
 
     const pset = this.pset.copy();
@@ -682,7 +718,7 @@ export class Updater {
         pubkey.equals(d.pubkey),
       )
     ) {
-      throw new Error('duplicated bip32 derivation pubkey');
+      throw new Error('Duplicated bip32 derivation pubkey');
     }
     pset.outputs[outIndex].bip32Derivation!.push(d);
     pset.sanityCheck();
@@ -696,7 +732,7 @@ export class Updater {
 
   addOutRedeemScript(outIndex: number, redeemScript: Buffer): this {
     if (outIndex < 0 || outIndex >= this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     const pset = this.pset.copy();
     pset.outputs[outIndex].redeemScript = redeemScript;
@@ -711,7 +747,7 @@ export class Updater {
 
   addOutWitnessScript(outIndex: number, witnessScript: Buffer): this {
     if (outIndex < 0 || outIndex >= this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     const pset = this.pset.copy();
     pset.outputs[outIndex].witnessScript = witnessScript;
@@ -726,16 +762,16 @@ export class Updater {
 
   addOutTapInternalKey(outIndex: number, tapInternalKey: TapInternalKey): this {
     if (outIndex < 0 || outIndex > this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     if (tapInternalKey.length !== 32) {
-      throw new Error('invalid taproot internal key length');
+      throw new Error('Invalid taproot internal key length');
     }
     if (
       this.pset.outputs[outIndex].tapInternalKey &&
       this.pset.outputs[outIndex].tapInternalKey!.length > 0
     ) {
-      throw new Error('duplicated taproot internal key');
+      throw new Error('Duplicated taproot internal key');
     }
 
     const pset = this.pset.copy();
@@ -751,10 +787,10 @@ export class Updater {
 
   addOutTapTree(outIndex: number, tapTree: TapTree): this {
     if (outIndex < 0 || outIndex > this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
     if (this.pset.outputs[outIndex].tapTree) {
-      throw new Error('duplicated taproot tree');
+      throw new Error('Duplicated taproot tree');
     }
 
     const pset = this.pset.copy();
@@ -770,11 +806,11 @@ export class Updater {
 
   addOutTapBIP32Derivation(outIndex: number, d: TapBip32Derivation): this {
     if (outIndex < 0 || outIndex >= this.pset.globals.outputCount) {
-      throw new Error('output index out of range');
+      throw new Error('Output index out of range');
     }
 
     if (d.pubkey.length !== 33) {
-      throw new Error('invalid output taproot pubkey length');
+      throw new Error('Invalid output taproot pubkey length');
     }
 
     const pset = this.pset.copy();
@@ -786,7 +822,7 @@ export class Updater {
         pubkey.equals(d.pubkey),
       )
     ) {
-      throw new Error('duplicated taproot bip32 derivation pubkey');
+      throw new Error('Duplicated taproot bip32 derivation pubkey');
     }
     pset.outputs[outIndex].tapBip32Derivation!.push(d);
     pset.sanityCheck();
@@ -800,30 +836,30 @@ export class Updater {
 
   private validateIssuanceInput(inIndex: number): void {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
 
     const input = this.pset.inputs[inIndex];
     if (input.issuanceAssetEntropy! && input.issuanceAssetEntropy!.length > 0) {
-      throw new Error('input ' + inIndex + ' already has an issuance');
+      throw new Error('Input ' + inIndex + ' already has an issuance');
     }
   }
 
   private validateReissuanceInput(inIndex: number): void {
     if (inIndex < 0 || inIndex >= this.pset.globals.inputCount) {
-      throw new Error('input index out of range');
+      throw new Error('Input index out of range');
     }
 
     const input = this.pset.inputs[inIndex];
     if (input.issuanceAssetEntropy! && input.issuanceAssetEntropy!.length > 0) {
-      throw new Error('input ' + inIndex + ' already has an issuance');
+      throw new Error(`Input ${inIndex} already has an issuance`);
     }
     const prevout = input.getUtxo();
     if (!prevout) {
-      throw new Error('input is missing prevout (non-)witness utxo');
+      throw new Error('Input is missing prevout (non-)witness utxo');
     }
     if (prevout.nonce.length <= 1) {
-      throw new Error('input prevout (non-)witness utxo must be confidential');
+      throw new Error('Input prevout (non-)witness utxo must be confidential');
     }
   }
 }
@@ -832,27 +868,27 @@ function validateAddInIssuanceArgs(args: IssuanceOpts): void {
   const assetAmount = args.assetAmount || 0;
   const tokenAmount = args.tokenAmount || 0;
   if (assetAmount <= 0 && tokenAmount <= 0) {
-    throw new Error('either asset or token amounts must be a positive number');
+    throw new Error('Either asset or token amounts must be a positive number');
   }
 
   if (assetAmount > 0) {
     if (!args.assetAddress || args.assetAddress!.length === 0) {
       throw new Error(
-        'asset address must be defined if asset amount is non-zero',
+        'Asset address must be defined if asset amount is non-zero',
       );
     }
   }
   if (tokenAmount > 0) {
     if (!args.tokenAddress || args.tokenAddress!.length === 0) {
       throw new Error(
-        'token address must be defined if token amount is non-zero',
+        'Token address must be defined if token amount is non-zero',
       );
     }
   }
 
   if (!matchAddressesType(args.assetAddress, args.tokenAddress)) {
     throw new Error(
-      'asset and token addresses must be of same network and both unconfidential or confidential',
+      'Asset and token addresses must be of same network and both unconfidential or confidential',
     );
   }
 }
@@ -863,35 +899,35 @@ function validateAddInReissuanceArgs(args: ReissuanceOpts): void {
       ? Buffer.from(args.entropy, 'hex').reverse()
       : args.entropy;
   if (entropy.length !== 32) {
-    throw new Error('invalid entropy length');
+    throw new Error('Invalid entropy length');
   }
   const blinder =
     typeof args.tokenAssetBlinder === 'string'
       ? Buffer.from(args.tokenAssetBlinder, 'hex').reverse()
       : args.tokenAssetBlinder;
   if (blinder.length !== 32) {
-    throw new Error('invalid token asset blinder length');
+    throw new Error('Invalid token asset blinder length');
   }
   if (args.assetAmount <= 0) {
-    throw new Error('asset amount must be a positive number');
+    throw new Error('Asset amount must be a positive number');
   }
   if (args.tokenAmount <= 0) {
-    throw new Error('token amount must be a positive number');
+    throw new Error('Token amount must be a positive number');
   }
   if (args.assetAddress.length === 0) {
-    throw new Error('missing asset address');
+    throw new Error('Missing asset address');
   }
   if (args.tokenAddress.length === 0) {
-    throw new Error('missing token address');
+    throw new Error('Missing token address');
   }
 
   if (!matchAddressesType(args.assetAddress, args.tokenAddress)) {
     throw new Error(
-      'asset and token addresses must be both of same network and both confidential',
+      'Asset and token addresses must be both of same network and both confidential',
     );
   }
   if (!isConfidential(args.assetAddress)) {
-    throw new Error('asset and token addresses must be both confidential');
+    throw new Error('Asset and token addresses must be both confidential');
   }
 }
 
@@ -917,7 +953,7 @@ function matchAddressesType(addrA?: string, addrB?: string): boolean {
 
 function validatePartialSignature(psig: PartialSig): void {
   if (psig.pubkey.length !== 33) {
-    throw new Error('invalid pubkey length');
+    throw new Error('Invalid pubkey length');
   }
   bscript.signature.decode(psig.signature);
 }


### PR DESCRIPTION
This fixes checks for sighash type by keeping in mind that `0` value (`SIGHASH_DEFAULT`) must be allowed.
This also fixes `Creator.newPset` by setting the global fallback locktime of the new pset to the one passed as function arg in case it's defined, and adds 2 new methods `addInTimeLocktime` and `addInHeightLocktime` to Updater role to set input required locktimes.

Closes #70 
Closes #63 
Closes #65

Please @tiero review this.