### PR TITLE
Add `initialIssuanceBlinded` parameter in `ReissuanceOpts`

### DIFF
--- a/src/psetv2/blinder.js
+++ b/src/psetv2/blinder.js
@@ -1,6 +1,7 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Blinder = void 0;
+const issuance_1 = require('../issuance');
 const transaction_1 = require('../transaction');
 class Blinder {
   constructor(pset, ownedInputs, validator, generator) {
@@ -381,8 +382,13 @@ class Blinder {
           assetBlinder: transaction_1.ZERO,
         });
         if (input.issuanceInflationKeys > 0) {
+          const entropy = input.getIssuanceEntropy();
+          const token = (0, issuance_1.calculateReissuanceToken)(
+            entropy,
+            input.blindedIssuance ?? true,
+          );
           inAssetsAndBlinders.push({
-            asset: input.getIssuanceInflationKeysHash(),
+            asset: token,
             assetBlinder: transaction_1.ZERO,
           });
         }

--- a/src/psetv2/input.d.ts
+++ b/src/psetv2/input.d.ts
@@ -66,7 +66,7 @@ export declare class PsetInput {
     isFinalized(): boolean;
     isTaproot(): boolean;
     getIssuanceAssetHash(): Buffer | undefined;
-    getIssuanceInflationKeysHash(): Buffer | undefined;
+    getIssuanceEntropy(): Buffer;
     getUtxo(): Output | undefined;
     toBuffer(): Buffer;
     private getKeyPairs;

--- a/src/psetv2/input.js
+++ b/src/psetv2/input.js
@@ -743,9 +743,9 @@ class PsetInput {
     }
     return (0, issuance_1.calculateAsset)(entropy);
   }
-  getIssuanceInflationKeysHash() {
+  getIssuanceEntropy() {
     if (!this.hasIssuance() && !this.hasReissuance()) {
-      return undefined;
+      throw new Error('input is not an (re)issuance');
     }
     if (!this.issuanceAssetEntropy) {
       throw new Error('missing issuance asset entropy');
@@ -757,10 +757,7 @@ class PsetInput {
         this.issuanceAssetEntropy,
       );
     }
-    return (0, issuance_1.calculateReissuanceToken)(
-      entropy,
-      this.blindedIssuance ?? true,
-    );
+    return entropy;
   }
   getUtxo() {
     if (!this.witnessUtxo && !this.nonWitnessUtxo) {

--- a/src/psetv2/updater.d.ts
+++ b/src/psetv2/updater.d.ts
@@ -23,6 +23,7 @@ export interface ReissuanceOpts {
     tokenAmount: number;
     tokenAddress: OutputDestination;
     tokenAssetBlinder: string | Buffer;
+    initialIssuanceBlinded?: boolean;
 }
 export interface UpdaterInput {
     txid: string;

--- a/src/psetv2/updater.d.ts
+++ b/src/psetv2/updater.d.ts
@@ -24,6 +24,7 @@ export interface ReissuanceOpts {
     tokenAddress: OutputDestination;
     tokenAssetBlinder: string | Buffer;
     initialIssuanceBlinded?: boolean;
+    blindedIssuance?: boolean;
 }
 export interface UpdaterInput {
     txid: string;

--- a/src/psetv2/updater.js
+++ b/src/psetv2/updater.js
@@ -328,8 +328,8 @@ class Updater {
     pset.inputs[inIndex].issuanceBlindingNonce = blindingNonce;
     pset.inputs[inIndex].issuanceValue = args.assetAmount;
     pset.inputs[inIndex].issuanceInflationKeys = 0;
-    if (args.initialIssuanceBlinded !== undefined) {
-      pset.inputs[inIndex].blindedIssuance = args.initialIssuanceBlinded;
+    if (args.blindedIssuance !== undefined) {
+      pset.inputs[inIndex].blindedIssuance = args.blindedIssuance;
     }
     if (args.assetAddress) {
       const { blindingPublicKey, script } = processOutputDestination(

--- a/src/psetv2/updater.js
+++ b/src/psetv2/updater.js
@@ -280,7 +280,10 @@ class Updater {
     }
     if (tokenAmount > 0) {
       const reissuanceToken = asset_1.AssetHash.fromBytes(
-        (0, issuance_1.calculateReissuanceToken)(entropy, args.blindedIssuance),
+        (0, issuance_1.calculateReissuanceToken)(
+          entropy,
+          args.blindedIssuance ?? true,
+        ),
       ).hex;
       const { blindingPublicKey, script } = processOutputDestination(
         args.tokenAddress,
@@ -316,12 +319,18 @@ class Updater {
       (0, issuance_1.calculateAsset)(entropy),
     ).hex;
     const reissuanceToken = asset_1.AssetHash.fromBytes(
-      (0, issuance_1.calculateReissuanceToken)(entropy, true),
+      (0, issuance_1.calculateReissuanceToken)(
+        entropy,
+        args.initialIssuanceBlinded ?? true,
+      ),
     ).hex;
     pset.inputs[inIndex].issuanceAssetEntropy = entropy;
     pset.inputs[inIndex].issuanceBlindingNonce = blindingNonce;
     pset.inputs[inIndex].issuanceValue = args.assetAmount;
     pset.inputs[inIndex].issuanceInflationKeys = 0;
+    if (args.initialIssuanceBlinded !== undefined) {
+      pset.inputs[inIndex].blindedIssuance = args.initialIssuanceBlinded;
+    }
     if (args.assetAddress) {
       const { blindingPublicKey, script } = processOutputDestination(
         args.assetAddress,

--- a/src/psetv2/zkp.js
+++ b/src/psetv2/zkp.js
@@ -5,6 +5,7 @@ const confidential_1 = require('../confidential');
 const transaction_1 = require('../transaction');
 const value_1 = require('../value');
 const utils_1 = require('./utils');
+const issuance_1 = require('../issuance');
 class ZKPValidator {
   constructor(zkpLib) {
     this.confidential = new confidential_1.Confidential(zkpLib);
@@ -217,7 +218,8 @@ class ZKPGenerator {
       }
       if (input.issuanceInflationKeys > 0) {
         const token = input.issuanceInflationKeys.toString(10);
-        const asset = input.getIssuanceInflationKeysHash();
+        const entropy = input.getIssuanceEntropy();
+        const asset = (0, issuance_1.calculateReissuanceToken)(entropy, true);
         if (!asset)
           throw new Error(
             'something went wrong during the inflation token hash computation',
@@ -410,7 +412,12 @@ class ZKPGenerator {
         assets.push(issAssetHash);
         assetBlinders.push(transaction_1.ZERO);
         if (!input.hasReissuance() && input.issuanceInflationKeys > 0) {
-          const inflationTokenAssetHash = input.getIssuanceInflationKeysHash();
+          const entropy = input.getIssuanceEntropy();
+          const inflationTokenAssetHash = (0,
+          issuance_1.calculateReissuanceToken)(
+            entropy,
+            input.blindedIssuance ?? true,
+          );
           if (!inflationTokenAssetHash)
             throw new Error(
               `something went wrong computing the issuance inflation keys hash on input #${i}`,

--- a/test/integration/psetv2.spec.ts
+++ b/test/integration/psetv2.spec.ts
@@ -350,6 +350,7 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
     );
     blinder.blindLast({ outputBlindingArgs });
     const rawTx = signTransaction(pset, [alice.keys], Transaction.SIGHASH_ALL);
+    console.log(rawTx.toHex());
     await regtestUtils.broadcast(rawTx.toHex());
   });
 
@@ -625,6 +626,143 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
       [alice.keys, alice.keys],
       Transaction.SIGHASH_ALL,
     );
+    await regtestUtils.broadcast(reissuanceTx.toHex());
+  });
+
+  it('can create (and broadcast via 3PBP) an unconfidential issuance and reissue with conf and unconf outputs', async () => {
+    const alice = createPayment('p2wpkh', undefined, undefined, true);
+    // const bob = createPayment('p2wpkh');
+    const aliceInputData = await getInputData(alice.payment, true, 'noredeem');
+
+    const inputs = [aliceInputData].map(({ hash, index }) => {
+      const txid = hash.slice().reverse().toString('hex');
+      return new CreatorInput(txid, index);
+    });
+    const outputs = [
+      new CreatorOutput(
+        lbtc,
+        99999400,
+        alice.payment.output,
+        alice.payment.blindkey,
+        0,
+      ),
+      new CreatorOutput(lbtc, 600),
+    ];
+
+    const pset = PsetCreator.newPset({ inputs, outputs });
+    let updater = new PsetUpdater(pset);
+    updater.addInWitnessUtxo(0, aliceInputData.witnessUtxo);
+    updater.addInUtxoRangeProof(0, aliceInputData.witnessUtxo.rangeProof);
+    updater.addInSighashType(0, Transaction.SIGHASH_ALL);
+    updater.addInIssuance(0, {
+      assetAmount: 1000,
+      tokenAmount: 1,
+      assetAddress: alice.payment.confidentialAddress!,
+      tokenAddress: alice.payment.confidentialAddress!,
+      blindedIssuance: false,
+    });
+
+    const zkpLib = await secp256k1();
+    const zkpValidator = new ZKPValidator(zkpLib);
+    const zkpGenerator = new ZKPGenerator(
+      zkpLib,
+      ZKPGenerator.WithBlindingKeysOfInputs(alice.blindingKeys),
+    );
+
+    const ownedInputs = zkpGenerator.unblindInputs(pset);
+    const outputBlindingArgs = zkpGenerator.blindOutputs(
+      pset,
+      Pset.ECCKeysGenerator(ecc),
+    );
+    let blinder = new PsetBlinder(
+      pset,
+      ownedInputs,
+      zkpValidator,
+      zkpGenerator,
+    );
+    blinder.blindLast({ outputBlindingArgs });
+    const issuanceTx = signTransaction(
+      pset,
+      [alice.keys],
+      Transaction.SIGHASH_ALL,
+    );
+    const issuanceTxid = await regtestUtils.broadcast(issuanceTx.toHex());
+
+    const assetEntropy = issuanceEntropyFromInput(issuanceTx.ins[0]);
+    const reissuanceInputs = [
+      new CreatorInput(issuanceTxid, 0),
+      new CreatorInput(issuanceTxid, 3),
+    ];
+    const reissuanceOutputs = [
+      new CreatorOutput(
+        lbtc,
+        99998700,
+        alice.payment.output,
+        // alice.payment.blindkey,
+        // 0,
+      ),
+      new CreatorOutput(lbtc, 700),
+    ];
+    const reissuancePset = PsetCreator.newPset({
+      inputs: reissuanceInputs,
+      outputs: reissuanceOutputs,
+    });
+
+    updater = new PsetUpdater(reissuancePset);
+    updater.addInWitnessUtxo(0, issuanceTx.outs[0]);
+    updater.addInWitnessUtxo(1, issuanceTx.outs[3]);
+    updater.addInUtxoRangeProof(0, issuanceTx.outs[0].rangeProof!);
+    updater.addInUtxoRangeProof(1, issuanceTx.outs[3].rangeProof!);
+    updater.addInReissuance(1, {
+      entropy: assetEntropy,
+      assetAmount: 1000,
+      assetAddress: alice.payment.confidentialAddress!,
+      tokenAmount: 1,
+      tokenAddress: alice.payment.confidentialAddress!,
+      tokenAssetBlinder: outputBlindingArgs[2].assetBlinder,
+      initialIssuanceBlinded: false,
+    });
+    updater.addInSighashType(0, Transaction.SIGHASH_ALL);
+    updater.addInSighashType(1, Transaction.SIGHASH_ALL);
+
+    const zkpGenerator2 = new ZKPGenerator(
+      zkpLib,
+      ZKPGenerator.WithBlindingKeysOfInputs([
+        alice.blindingKeys[0],
+        alice.blindingKeys[0],
+      ]),
+    );
+
+    const reissuanceownedInputs = zkpGenerator2.unblindInputs(reissuancePset);
+    const reissuanceBlindingArgs = zkpGenerator2.blindIssuances(
+      reissuancePset,
+      {
+        1: alice.blindingKeys[0],
+      },
+    );
+
+    const reissuanceOutputBlindingArgs = zkpGenerator2.blindOutputs(
+      reissuancePset,
+      Pset.ECCKeysGenerator(ecc),
+    );
+
+    blinder = new PsetBlinder(
+      reissuancePset,
+      reissuanceownedInputs,
+      zkpValidator,
+      zkpGenerator2,
+    );
+    blinder.blindLast({
+      issuanceBlindingArgs: reissuanceBlindingArgs,
+      outputBlindingArgs: reissuanceOutputBlindingArgs,
+    });
+
+    const reissuanceTx = signTransaction(
+      reissuancePset,
+      [alice.keys, alice.keys],
+      Transaction.SIGHASH_ALL,
+    );
+    console.log(reissuanceTx.toHex());
     await regtestUtils.broadcast(reissuanceTx.toHex());
   });
 

--- a/test/integration/psetv2.spec.ts
+++ b/test/integration/psetv2.spec.ts
@@ -350,7 +350,6 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
     );
     blinder.blindLast({ outputBlindingArgs });
     const rawTx = signTransaction(pset, [alice.keys], Transaction.SIGHASH_ALL);
-    console.log(rawTx.toHex());
     await regtestUtils.broadcast(rawTx.toHex());
   });
 
@@ -629,9 +628,9 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
     await regtestUtils.broadcast(reissuanceTx.toHex());
   });
 
-  it('can create (and broadcast via 3PBP) an unconfidential issuance and reissue with conf and unconf outputs', async () => {
+  it('can create (and broadcast via 3PBP) an unconfidential issuance and reissue (unconfidential) with confidential token output', async () => {
     const alice = createPayment('p2wpkh', undefined, undefined, true);
-    // const bob = createPayment('p2wpkh');
+    const bob = createPayment('p2wpkh');
     const aliceInputData = await getInputData(alice.payment, true, 'noredeem');
 
     const inputs = [aliceInputData].map(({ hash, index }) => {
@@ -698,8 +697,8 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
         lbtc,
         99998700,
         alice.payment.output,
-        // alice.payment.blindkey,
-        // 0,
+        alice.payment.blindkey,
+        0,
       ),
       new CreatorOutput(lbtc, 700),
     ];
@@ -716,7 +715,7 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
     updater.addInReissuance(1, {
       entropy: assetEntropy,
       assetAmount: 1000,
-      assetAddress: alice.payment.confidentialAddress!,
+      assetAddress: bob.payment.address!,
       tokenAmount: 1,
       tokenAddress: alice.payment.confidentialAddress!,
       tokenAssetBlinder: outputBlindingArgs[2].assetBlinder,
@@ -734,12 +733,6 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
     );
 
     const reissuanceownedInputs = zkpGenerator2.unblindInputs(reissuancePset);
-    const reissuanceBlindingArgs = zkpGenerator2.blindIssuances(
-      reissuancePset,
-      {
-        1: alice.blindingKeys[0],
-      },
-    );
 
     const reissuanceOutputBlindingArgs = zkpGenerator2.blindOutputs(
       reissuancePset,
@@ -753,7 +746,6 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
       zkpGenerator2,
     );
     blinder.blindLast({
-      issuanceBlindingArgs: reissuanceBlindingArgs,
       outputBlindingArgs: reissuanceOutputBlindingArgs,
     });
 
@@ -762,7 +754,6 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
       [alice.keys, alice.keys],
       Transaction.SIGHASH_ALL,
     );
-    console.log(reissuanceTx.toHex());
     await regtestUtils.broadcast(reissuanceTx.toHex());
   });
 

--- a/ts_src/psetv2/blinder.ts
+++ b/ts_src/psetv2/blinder.ts
@@ -1,4 +1,5 @@
 import { UnblindOutputResult } from '../confidential';
+import { calculateReissuanceToken } from '../issuance';
 import { ZERO } from '../transaction';
 import { Pset } from './pset';
 import { ZKPGenerator, ZKPValidator } from './zkp';
@@ -475,8 +476,13 @@ export class Blinder {
           assetBlinder: ZERO,
         });
         if (input.issuanceInflationKeys! > 0) {
+          const entropy = input.getIssuanceEntropy();
+          const token = calculateReissuanceToken(
+            entropy,
+            input.blindedIssuance ?? true,
+          );
           inAssetsAndBlinders.push({
-            asset: input.getIssuanceInflationKeysHash()!,
+            asset: token,
             assetBlinder: ZERO,
           });
         }

--- a/ts_src/psetv2/input.ts
+++ b/ts_src/psetv2/input.ts
@@ -6,11 +6,7 @@ import {
   varuint,
   writeUInt64LE,
 } from '../bufferutils';
-import {
-  calculateAsset,
-  calculateReissuanceToken,
-  generateEntropy,
-} from '../issuance';
+import { calculateAsset, generateEntropy } from '../issuance';
 import { Output, Transaction, ZERO } from '../transaction';
 import { decodeBip32Derivation, encodeBIP32Derivation } from './bip32';
 import { InputProprietaryTypes, InputTypes } from './fields';
@@ -782,9 +778,9 @@ export class PsetInput {
     return calculateAsset(entropy);
   }
 
-  getIssuanceInflationKeysHash(): Buffer | undefined {
+  getIssuanceEntropy(): Buffer {
     if (!this.hasIssuance() && !this.hasReissuance()) {
-      return undefined;
+      throw new Error('input is not an (re)issuance');
     }
 
     if (!this.issuanceAssetEntropy) {
@@ -798,7 +794,7 @@ export class PsetInput {
         this.issuanceAssetEntropy!,
       );
     }
-    return calculateReissuanceToken(entropy, this.blindedIssuance ?? true);
+    return entropy;
   }
 
   getUtxo(): Output | undefined {

--- a/ts_src/psetv2/updater.ts
+++ b/ts_src/psetv2/updater.ts
@@ -63,6 +63,7 @@ export interface ReissuanceOpts {
   tokenAddress: OutputDestination;
   tokenAssetBlinder: string | Buffer;
   initialIssuanceBlinded?: boolean;
+  blindedIssuance?: boolean;
 }
 
 export interface UpdaterInput {
@@ -416,8 +417,8 @@ export class Updater {
     pset.inputs[inIndex].issuanceValue = args.assetAmount;
     pset.inputs[inIndex].issuanceInflationKeys = 0;
 
-    if (args.initialIssuanceBlinded !== undefined) {
-      pset.inputs[inIndex].blindedIssuance = args.initialIssuanceBlinded;
+    if (args.blindedIssuance !== undefined) {
+      pset.inputs[inIndex].blindedIssuance = args.blindedIssuance;
     }
 
     if (args.assetAddress) {

--- a/ts_src/psetv2/updater.ts
+++ b/ts_src/psetv2/updater.ts
@@ -367,7 +367,7 @@ export class Updater {
 
     if (tokenAmount > 0) {
       const reissuanceToken = AssetHash.fromBytes(
-        calculateReissuanceToken(entropy, args.blindedIssuance),
+        calculateReissuanceToken(entropy, args.blindedIssuance ?? true),
       ).hex;
       const { blindingPublicKey, script } = processOutputDestination(
         args.tokenAddress!,

--- a/ts_src/psetv2/updater.ts
+++ b/ts_src/psetv2/updater.ts
@@ -62,6 +62,7 @@ export interface ReissuanceOpts {
   tokenAmount: number;
   tokenAddress: OutputDestination;
   tokenAssetBlinder: string | Buffer;
+  initialIssuanceBlinded?: boolean;
 }
 
 export interface UpdaterInput {
@@ -407,13 +408,17 @@ export class Updater {
         : args.tokenAssetBlinder;
     const asset = AssetHash.fromBytes(calculateAsset(entropy)).hex;
     const reissuanceToken = AssetHash.fromBytes(
-      calculateReissuanceToken(entropy, true),
+      calculateReissuanceToken(entropy, args.initialIssuanceBlinded ?? true),
     ).hex;
 
     pset.inputs[inIndex].issuanceAssetEntropy = entropy;
     pset.inputs[inIndex].issuanceBlindingNonce = blindingNonce;
     pset.inputs[inIndex].issuanceValue = args.assetAmount;
     pset.inputs[inIndex].issuanceInflationKeys = 0;
+
+    if (args.initialIssuanceBlinded !== undefined) {
+      pset.inputs[inIndex].blindedIssuance = args.initialIssuanceBlinded;
+    }
 
     if (args.assetAddress) {
       const { blindingPublicKey, script } = processOutputDestination(

--- a/ts_src/psetv2/zkp.ts
+++ b/ts_src/psetv2/zkp.ts
@@ -14,6 +14,7 @@ import type {
   OutputBlindingArgs,
   OwnedInput,
 } from './blinder';
+import { calculateReissuanceToken } from '../issuance';
 
 export class ZKPValidator {
   private confidential: Confidential;
@@ -284,7 +285,8 @@ export class ZKPGenerator {
 
       if (input.issuanceInflationKeys! > 0) {
         const token = input.issuanceInflationKeys!.toString(10);
-        const asset = input.getIssuanceInflationKeysHash();
+        const entropy = input.getIssuanceEntropy();
+        const asset = calculateReissuanceToken(entropy, true);
         if (!asset)
           throw new Error(
             'something went wrong during the inflation token hash computation',
@@ -510,7 +512,12 @@ export class ZKPGenerator {
         assetBlinders.push(ZERO);
 
         if (!input.hasReissuance() && input.issuanceInflationKeys! > 0) {
-          const inflationTokenAssetHash = input.getIssuanceInflationKeysHash();
+          const entropy = input.getIssuanceEntropy();
+
+          const inflationTokenAssetHash = calculateReissuanceToken(
+            entropy,
+            input.blindedIssuance ?? true,
+          );
           if (!inflationTokenAssetHash)
             throw new Error(
               `something went wrong computing the issuance inflation keys hash on input #${i}`,


### PR DESCRIPTION
* reissuance pset needs to set the `blindedIssuance` flag to `false` if the initial issuance transaction is unconfidential. Now can be done using the `initialIssuanceBlinded` parameter.
* add a test case: unconfidential issuance to confidential outputs + unconfidential reissuance with token output blinded.

@tiero @altafan  please review 