### PR TITLE
fix `ZKPGenerator.maybeUnblindUtxo` function

### DIFF
--- a/src/psetv2/zkp.js
+++ b/src/psetv2/zkp.js
@@ -6,6 +6,7 @@ const transaction_1 = require('../transaction');
 const value_1 = require('../value');
 const utils_1 = require('./utils');
 const issuance_1 = require('../issuance');
+const asset_1 = require('../asset');
 class ZKPValidator {
   constructor(zkpLib) {
     this.confidential = new confidential_1.Confidential(zkpLib);
@@ -432,7 +433,7 @@ class ZKPGenerator {
   maybeUnblindInUtxos(pset) {
     if (this.ownedInputs && this.ownedInputs.length > 0) {
       return pset.inputs.map((input, i) => {
-        const ownedInput = this.ownedInputs.find(({ index }) => index === i);
+        const ownedInput = this.ownedInputs?.find(({ index }) => index === i);
         if (ownedInput) {
           return {
             value: '',
@@ -441,10 +442,14 @@ class ZKPGenerator {
             assetBlindingFactor: ownedInput.assetBlindingFactor,
           };
         }
+        const utxo = input.getUtxo();
+        if (!utxo) {
+          throw new Error(`Missing utxo for input #${i}`);
+        }
         return {
           value: '',
           valueBlindingFactor: Buffer.from([]),
-          asset: input.getUtxo().asset,
+          asset: asset_1.AssetHash.fromBytes(utxo.asset).bytesWithoutPrefix,
           assetBlindingFactor: transaction_1.ZERO,
         };
       });


### PR DESCRIPTION
* `getUtxo().asset` is the prefixed asset buffer (33 bytes). The fix just ensures that we are providing 32 bytes buffer (asset without prefix) as `unblindedInput.asset`.

related to https://github.com/ionio-lang/ionio/pull/29

@tiero @altafan please review