### PR TITLE
Add pset v2 test case (confidential & unconfidential inputs) + fix `blindOutputs`

### DIFF
--- a/src/psetv2/blinder.js
+++ b/src/psetv2/blinder.js
@@ -1,6 +1,7 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Blinder = void 0;
+const asset_1 = require('../asset');
 const issuance_1 = require('../issuance');
 const transaction_1 = require('../transaction');
 class Blinder {
@@ -371,7 +372,8 @@ class Blinder {
             assetBlinder: ownedInput.assetBlindingFactor,
           }
         : {
-            asset: input.getUtxo().asset,
+            asset: asset_1.AssetHash.fromBytes(input.getUtxo().asset)
+              .bytesWithoutPrefix,
             assetBlinder: transaction_1.ZERO,
           };
     });

--- a/test/integration/psetv2.spec.ts
+++ b/test/integration/psetv2.spec.ts
@@ -186,17 +186,23 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
     await regtestUtils.broadcast(rawTx.toHex());
   });
 
-  it.only('can create (and broadcast via 3PBP) a confidential Transaction w/ confidential and unconfidential inputs', async () => {
+  it('can create (and broadcast via 3PBP) a confidential Transaction w/ confidential and unconfidential inputs', async () => {
     const alice = createPayment('p2pkh', undefined, undefined, true);
     const unconfidentialAlice = createPayment('p2pkh');
     const bob = createPayment('p2wpkh', undefined, undefined, true);
     const aliceInputData = await getInputData(alice.payment, true, 'noredeem');
-    const unconfidentialAliceInputData = await getInputData(unconfidentialAlice.payment, true, 'noredeem');
+    const unconfidentialAliceInputData = await getInputData(
+      unconfidentialAlice.payment,
+      true,
+      'noredeem',
+    );
 
-    const inputs = [aliceInputData, unconfidentialAliceInputData].map(({ hash, index }) => {
-      const txid = hash.slice().reverse().toString('hex');
-      return new CreatorInput(txid, index);
-    });
+    const inputs = [aliceInputData, unconfidentialAliceInputData].map(
+      ({ hash, index }) => {
+        const txid = hash.slice().reverse().toString('hex');
+        return new CreatorInput(txid, index);
+      },
+    );
     const outputs = [
       new CreatorOutput(
         lbtc,
@@ -242,7 +248,11 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
       zkpGenerator,
     );
     blinder.blindLast({ outputBlindingArgs });
-    const rawTx = signTransaction(pset, [alice.keys, unconfidentialAlice.keys], Transaction.SIGHASH_ALL);
+    const rawTx = signTransaction(
+      pset,
+      [alice.keys, unconfidentialAlice.keys],
+      Transaction.SIGHASH_ALL,
+    );
     console.log(rawTx.toHex());
     await regtestUtils.broadcast(rawTx.toHex());
   });

--- a/test/integration/psetv2.spec.ts
+++ b/test/integration/psetv2.spec.ts
@@ -186,6 +186,67 @@ describe('liquidjs-lib (transactions with psetv2)', () => {
     await regtestUtils.broadcast(rawTx.toHex());
   });
 
+  it.only('can create (and broadcast via 3PBP) a confidential Transaction w/ confidential and unconfidential inputs', async () => {
+    const alice = createPayment('p2pkh', undefined, undefined, true);
+    const unconfidentialAlice = createPayment('p2pkh');
+    const bob = createPayment('p2wpkh', undefined, undefined, true);
+    const aliceInputData = await getInputData(alice.payment, true, 'noredeem');
+    const unconfidentialAliceInputData = await getInputData(unconfidentialAlice.payment, true, 'noredeem');
+
+    const inputs = [aliceInputData, unconfidentialAliceInputData].map(({ hash, index }) => {
+      const txid = hash.slice().reverse().toString('hex');
+      return new CreatorInput(txid, index);
+    });
+    const outputs = [
+      new CreatorOutput(
+        lbtc,
+        60000000,
+        bob.payment.output,
+        bob.payment.blindkey,
+        0,
+      ),
+      new CreatorOutput(
+        lbtc,
+        39999500 + 1_0000_0000,
+        alice.payment.output,
+        alice.payment.blindkey,
+        0,
+      ),
+      new CreatorOutput(lbtc, 500),
+    ];
+
+    const pset = PsetCreator.newPset({ inputs, outputs });
+    const updater = new PsetUpdater(pset);
+    updater.addInWitnessUtxo(0, aliceInputData.witnessUtxo);
+    updater.addInUtxoRangeProof(0, aliceInputData.witnessUtxo.rangeProof);
+    updater.addInSighashType(0, Transaction.SIGHASH_ALL);
+
+    updater.addInWitnessUtxo(1, unconfidentialAliceInputData.witnessUtxo);
+    updater.addInSighashType(1, Transaction.SIGHASH_ALL);
+
+    const zkpLib = await secp256k1();
+    const zkpValidator = new ZKPValidator(zkpLib);
+    const zkpGenerator = new ZKPGenerator(
+      zkpLib,
+      ZKPGenerator.WithBlindingKeysOfInputs(alice.blindingKeys),
+    );
+    const ownedInputs = zkpGenerator.unblindInputs(pset);
+    const outputBlindingArgs = zkpGenerator.blindOutputs(
+      pset,
+      Pset.ECCKeysGenerator(ecc),
+    );
+    const blinder = new PsetBlinder(
+      pset,
+      ownedInputs,
+      zkpValidator,
+      zkpGenerator,
+    );
+    blinder.blindLast({ outputBlindingArgs });
+    const rawTx = signTransaction(pset, [alice.keys, unconfidentialAlice.keys], Transaction.SIGHASH_ALL);
+    console.log(rawTx.toHex());
+    await regtestUtils.broadcast(rawTx.toHex());
+  });
+
   it('can create (and broadcast via 3PBP) a confidential Transaction w/ dummy confidential output', async () => {
     const alice = createPayment('p2pkh', undefined, undefined, true);
     const bob = createPayment('p2wpkh');

--- a/ts_src/psetv2/blinder.ts
+++ b/ts_src/psetv2/blinder.ts
@@ -1,3 +1,4 @@
+import { AssetHash } from '../asset';
 import { UnblindOutputResult } from '../confidential';
 import { calculateReissuanceToken } from '../issuance';
 import { ZERO } from '../transaction';
@@ -459,13 +460,14 @@ export class Blinder {
   ): void {
     const inAssetsAndBlinders = this.pset.inputs.map((input, i) => {
       const ownedInput = this.ownedInputs.find(({ index }) => index === i);
-      return ownedInput!
+      return ownedInput
         ? {
             asset: ownedInput.asset,
             assetBlinder: ownedInput.assetBlindingFactor,
           }
         : {
-            asset: input.getUtxo()!.asset,
+            asset: AssetHash.fromBytes(input.getUtxo()!.asset)
+              .bytesWithoutPrefix,
             assetBlinder: ZERO,
           };
     });


### PR DESCRIPTION
* fix the way we get the input asset tags in case of unconfidential input for output surjection proof in `blindOutputs` function.

it closes #90 

it works with https://github.com/ionio-lang/ionio/pull/29 (tested with my fork)

@tiero @altafan please review