### PR TITLE
add `Pset.estimateVirtualSize` method

### DIFF
--- a/src/address.d.ts
+++ b/src/address.d.ts
@@ -30,12 +30,14 @@ export declare enum AddressType {
     ConfidentialP2Wsh = 7
 }
 export declare enum ScriptType {
-    P2Pkh = 0,
-    P2Sh = 1,
-    P2Wpkh = 2,
-    P2Wsh = 3,
-    P2Tr = 4
+    P2PK = 0,
+    P2PKH = 1,
+    P2SH = 2,
+    P2WPKH = 3,
+    P2WSH = 4,
+    P2TR = 5
 }
+export declare function getScriptSigSize(type: ScriptType): number;
 export declare function fromBase58Check(address: string): Base58CheckResult;
 export declare function fromBech32(address: string): Bech32Result;
 export declare function fromBlech32(address: string): Blech32Result;

--- a/src/address.js
+++ b/src/address.js
@@ -58,6 +58,7 @@ exports.getScriptType =
   exports.fromBlech32 =
   exports.fromBech32 =
   exports.fromBase58Check =
+  exports.getScriptSigSize =
   exports.ScriptType =
   exports.AddressType =
     void 0;
@@ -106,12 +107,29 @@ var AddressType;
 })((AddressType = exports.AddressType || (exports.AddressType = {})));
 var ScriptType;
 (function (ScriptType) {
-  ScriptType[(ScriptType['P2Pkh'] = 0)] = 'P2Pkh';
-  ScriptType[(ScriptType['P2Sh'] = 1)] = 'P2Sh';
-  ScriptType[(ScriptType['P2Wpkh'] = 2)] = 'P2Wpkh';
-  ScriptType[(ScriptType['P2Wsh'] = 3)] = 'P2Wsh';
-  ScriptType[(ScriptType['P2Tr'] = 4)] = 'P2Tr';
+  ScriptType[(ScriptType['P2PK'] = 0)] = 'P2PK';
+  ScriptType[(ScriptType['P2PKH'] = 1)] = 'P2PKH';
+  ScriptType[(ScriptType['P2SH'] = 2)] = 'P2SH';
+  ScriptType[(ScriptType['P2WPKH'] = 3)] = 'P2WPKH';
+  ScriptType[(ScriptType['P2WSH'] = 4)] = 'P2WSH';
+  ScriptType[(ScriptType['P2TR'] = 5)] = 'P2TR';
 })((ScriptType = exports.ScriptType || (exports.ScriptType = {})));
+function getScriptSigSize(type) {
+  switch (type) {
+    case ScriptType.P2PKH:
+      return 108;
+    case ScriptType.P2SH:
+      return 35;
+    case ScriptType.P2WPKH:
+      return 1;
+    case ScriptType.P2WSH:
+      return 1;
+    case ScriptType.P2TR:
+      return 1;
+  }
+  return 0;
+}
+exports.getScriptSigSize = getScriptSigSize;
 function isConfidentialAddressType(addressType) {
   return addressType >= 4;
 }
@@ -461,15 +479,15 @@ function getScriptType(script) {
   switch (script[0]) {
     case ops_1.OPS.OP_0:
       if (script.slice(2).length === 20) {
-        return ScriptType.P2Wpkh;
+        return ScriptType.P2WPKH;
       }
-      return ScriptType.P2Wsh;
+      return ScriptType.P2WSH;
     case ops_1.OPS.OP_HASH160:
-      return ScriptType.P2Sh;
+      return ScriptType.P2SH;
     case ops_1.OPS.OP_DUP:
-      return ScriptType.P2Pkh;
+      return ScriptType.P2PKH;
     case ops_1.OPS.OP_1:
-      return ScriptType.P2Tr;
+      return ScriptType.P2TR;
     default:
       throw new Error('unknow script type');
   }

--- a/src/psetv2/input.d.ts
+++ b/src/psetv2/input.d.ts
@@ -5,6 +5,7 @@ import { Output, Transaction } from '../transaction';
 import { Bip32Derivation, PartialSig, TapBip32Derivation, TapInternalKey, TapKeySig, TapLeafScript, TapMerkleRoot, TapScriptSig } from './interfaces';
 import { KeyPair } from './key_pair';
 import { ProprietaryData } from './proprietary_data';
+import { ScriptType } from '../address';
 export declare class InputDuplicateFieldError extends Error {
     constructor(message?: string);
 }
@@ -68,6 +69,7 @@ export declare class PsetInput {
     getIssuanceAssetHash(): Buffer | undefined;
     getIssuanceEntropy(): Buffer;
     getUtxo(): Output | undefined;
+    scriptType(): ScriptType;
     toBuffer(): Buffer;
     private getKeyPairs;
 }

--- a/src/psetv2/input.js
+++ b/src/psetv2/input.js
@@ -58,6 +58,7 @@ const bscript = __importStar(require('../script'));
 const utils_1 = require('./utils');
 const asset_1 = require('../asset');
 const value_1 = require('../value');
+const address_1 = require('../address');
 class InputDuplicateFieldError extends Error {
   constructor(message) {
     if (message) {
@@ -769,6 +770,12 @@ class PsetInput {
       return utxo;
     }
     return this.nonWitnessUtxo.outs[this.previousTxIndex];
+  }
+  scriptType() {
+    const utxo = this.getUtxo();
+    if (!utxo)
+      throw new Error('missing input utxo, cannot determine script type');
+    return (0, address_1.getScriptType)(utxo.script);
   }
   toBuffer() {
     const keyPairs = this.getKeyPairs();

--- a/src/psetv2/pset.d.ts
+++ b/src/psetv2/pset.d.ts
@@ -41,5 +41,6 @@ export declare class Pset {
     getInputPreimage(index: number, sighashType: number, genesisBlockHash?: Buffer, leafHash?: Buffer): Buffer;
     toBase64(): string;
     toBuffer(): Buffer;
+    estimateVirtualSize(): number;
     private isDuplicatedInput;
 }

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -74,11 +74,28 @@ export enum AddressType {
 }
 
 export enum ScriptType {
-  P2Pkh = 0,
-  P2Sh = 1,
-  P2Wpkh = 2,
-  P2Wsh = 3,
-  P2Tr = 4,
+  P2PK = 0,
+  P2PKH,
+  P2SH,
+  P2WPKH,
+  P2WSH,
+  P2TR,
+}
+
+export function getScriptSigSize(type: ScriptType): number {
+  switch (type) {
+    case ScriptType.P2PKH:
+      return 108;
+    case ScriptType.P2SH:
+      return 35;
+    case ScriptType.P2WPKH:
+      return 1;
+    case ScriptType.P2WSH:
+      return 1;
+    case ScriptType.P2TR:
+      return 1;
+  }
+  return 0;
 }
 
 function isConfidentialAddressType(addressType: AddressType): boolean {
@@ -504,15 +521,15 @@ export function getScriptType(script: Buffer): ScriptType {
   switch (script[0]) {
     case OPS.OP_0:
       if (script.slice(2).length === 20) {
-        return ScriptType.P2Wpkh;
+        return ScriptType.P2WPKH;
       }
-      return ScriptType.P2Wsh;
+      return ScriptType.P2WSH;
     case OPS.OP_HASH160:
-      return ScriptType.P2Sh;
+      return ScriptType.P2SH;
     case OPS.OP_DUP:
-      return ScriptType.P2Pkh;
+      return ScriptType.P2PKH;
     case OPS.OP_1:
-      return ScriptType.P2Tr;
+      return ScriptType.P2TR;
     default:
       throw new Error('unknow script type');
   }

--- a/ts_src/psetv2/input.ts
+++ b/ts_src/psetv2/input.ts
@@ -27,6 +27,7 @@ import * as bscript from '../script';
 import { isP2TR } from './utils';
 import { AssetHash } from '../asset';
 import { ElementsValue } from '../value';
+import { getScriptType, ScriptType } from '../address';
 
 export class InputDuplicateFieldError extends Error {
   constructor(message?: string) {
@@ -808,6 +809,13 @@ export class PsetInput {
       return utxo;
     }
     return this.nonWitnessUtxo!.outs[this.previousTxIndex];
+  }
+
+  scriptType(): ScriptType {
+    const utxo = this.getUtxo();
+    if (!utxo)
+      throw new Error('missing input utxo, cannot determine script type');
+    return getScriptType(utxo.script);
   }
 
   toBuffer(): Buffer {


### PR DESCRIPTION
add a method greatly inspired by [ocean's EstimateTxSize](https://github.com/vulpemventures/ocean/blob/3bf1a7e78aa4c4960ca9d48ec4088cdb3f347bc2/pkg/wallet/estimation.go#L18) function.

The function aims to compute the estimated virtual size of the pset extracted transaction. The function takes into account the possible confidentiality of the outputs even if there aren't blinded.

EDIT: CI is failing at `format:ci` step but format:ci pass locally, any idea about this?

@altafan please review