### PR TITLE
Allow direct sequence number 0

### DIFF
--- a/src/psetv2/creator.d.ts
+++ b/src/psetv2/creator.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
-import { Pset } from './pset';
 import { PsetInput } from './input';
 import { PsetOutput } from './output';
+import { Pset } from './pset';
 export declare class CreatorInput {
     txid: string;
     txIndex: number;

--- a/src/psetv2/creator.js
+++ b/src/psetv2/creator.js
@@ -6,19 +6,19 @@ var __importDefault =
   };
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Creator = exports.CreatorOutput = exports.CreatorInput = void 0;
+const bitset_1 = __importDefault(require('bitset'));
+const asset_1 = require('../asset');
+const bufferutils_1 = require('../bufferutils');
+const transaction_1 = require('../transaction');
 const globals_1 = require('./globals');
-const pset_1 = require('./pset');
 const input_1 = require('./input');
 const output_1 = require('./output');
-const bufferutils_1 = require('../bufferutils');
-const asset_1 = require('../asset');
-const transaction_1 = require('../transaction');
-const bitset_1 = __importDefault(require('bitset'));
+const pset_1 = require('./pset');
 class CreatorInput {
   constructor(txid, txIndex, sequence, heightLocktime, timeLocktime) {
     this.txid = txid;
     this.txIndex = txIndex;
-    this.sequence = sequence || transaction_1.Transaction.DEFAULT_SEQUENCE;
+    this.sequence = sequence ?? transaction_1.Transaction.DEFAULT_SEQUENCE;
     this.heightLocktime = heightLocktime || 0;
     this.timeLocktime = timeLocktime || 0;
   }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -241,7 +241,7 @@ class Transaction {
         peginWitness: EMPTY_WITNESS,
         issuanceRangeProof: EMPTY_BUFFER,
         inflationRangeProof: EMPTY_BUFFER,
-        sequence: sequence || Transaction.DEFAULT_SEQUENCE,
+        sequence: sequence ?? Transaction.DEFAULT_SEQUENCE,
       }) - 1
     );
   }

--- a/ts_src/psetv2/creator.ts
+++ b/ts_src/psetv2/creator.ts
@@ -1,11 +1,11 @@
+import BitSet from 'bitset';
+import { AssetHash } from '../asset';
+import { reverseBuffer } from '../bufferutils';
+import { Transaction } from '../transaction';
 import { PsetGlobal } from './globals';
-import { Pset } from './pset';
 import { PsetInput } from './input';
 import { PsetOutput } from './output';
-import { reverseBuffer } from '../bufferutils';
-import { AssetHash } from '../asset';
-import { Transaction } from '../transaction';
-import BitSet from 'bitset';
+import { Pset } from './pset';
 
 export class CreatorInput {
   txid: string;
@@ -23,7 +23,7 @@ export class CreatorInput {
   ) {
     this.txid = txid;
     this.txIndex = txIndex;
-    this.sequence = sequence || Transaction.DEFAULT_SEQUENCE;
+    this.sequence = sequence ?? Transaction.DEFAULT_SEQUENCE;
     this.heightLocktime = heightLocktime || 0;
     this.timeLocktime = timeLocktime || 0;
   }

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -264,7 +264,7 @@ export class Transaction {
         peginWitness: EMPTY_WITNESS,
         issuanceRangeProof: EMPTY_BUFFER,
         inflationRangeProof: EMPTY_BUFFER,
-        sequence: sequence || Transaction.DEFAULT_SEQUENCE,
+        sequence: sequence ?? Transaction.DEFAULT_SEQUENCE,
       }) - 1
     );
   }


### PR DESCRIPTION
I found that when directly setting the `sequence` to `0` on `psbt.addInput` it will fall back to the default.

This behaviour is inconsistent with `bitcoinjs-lib` which allows it to be set directly and explicitely to `0`