### PR TITLE
Fix heuristic for explicit outputs when unblinding

### DIFF
--- a/src/psetv2/zkp.js
+++ b/src/psetv2/zkp.js
@@ -371,7 +371,11 @@ class ZKPGenerator {
     return Buffer.from(ecc.privateAdd(result, valueBlinder));
   }
   unblindUtxo(out) {
-    if (out.nonce.length === 1) {
+    if (
+      out.nonce.length === 1 ||
+      out.rangeProof === undefined ||
+      out.rangeProof.length === 0
+    ) {
       return {
         index: 0,
         value: value_1.ElementsValue.fromBytes(out.value).number.toString(10),

--- a/ts_src/psetv2/zkp.ts
+++ b/ts_src/psetv2/zkp.ts
@@ -454,7 +454,11 @@ export class ZKPGenerator {
   }
 
   private unblindUtxo(out: Output): OwnedInput {
-    if (out.nonce.length === 1) {
+    if (
+      out.nonce.length === 1 ||
+      out.rangeProof === undefined ||
+      out.rangeProof.length === 0
+    ) {
       return {
         index: 0,
         value: ElementsValue.fromBytes(out.value).number.toString(10),


### PR DESCRIPTION
We had a case in which the nonce was set for an explicit output. The output confused the library and it tried to unblind it. That failed and caused weird behaviour and the PSET blinding to fail.

We need a `rangeProof` to unblind anyways, so checking if there is one before trying to unblind makes sense.